### PR TITLE
Yixin add basic announcement card component

### DIFF
--- a/frontend/src/fixtures/announcementFixtures.js
+++ b/frontend/src/fixtures/announcementFixtures.js
@@ -24,7 +24,7 @@ const announcementFixtures = {
         {
             "id": 3,
             "commonsId": 1,
-            "startDate": "2024-11-12T00:00:00",
+            "startDate": "2024-1-12T00:00:00",
             "endDate": "2025-10-12T00:00:00",
             "announcementText": "This is another test announcement for commons id 1. This one does have an end date."
         }

--- a/frontend/src/main/components/Announcement/AnnouncementCard.js
+++ b/frontend/src/main/components/Announcement/AnnouncementCard.js
@@ -1,28 +1,11 @@
 import React from "react";
 import { Card, Container, Row, Col } from "react-bootstrap";
 
-const curr = new Date();
-
-function isFutureDate(startingDate) {
-    const startYear = parseInt(startingDate);
-    const startMonth = parseInt(startingDate.substring(5,7));
-    const startDate = parseInt(startingDate.substring(8,10));
-    const currYear = curr.getFullYear();
-    const currMonth = curr.getMonth() + 1;
-    const currDate = curr.getDate();
-
-    if (startYear === currYear) {
-        if (startMonth === currMonth) {
-            // Stryker disable next-line all: mutation test unreasonable
-            return startDate > currDate;
-        } else {
-            // Stryker disable next-line all: mutation test unreasonable
-            return startMonth > currMonth;
-        }
-    } else {
-        // Stryker disable next-line all: mutation test unreasonable
-        return startYear > currYear;
-    }
+export function isFutureDate(startingDate) {
+    const curr = new Date();
+    const startDate = new Date(startingDate);
+    // Stryker disable next-line all: mutation test unreasonable
+    return startDate > curr;
 }
 
 const AnnouncementCard = ({ announcement }) => {

--- a/frontend/src/main/components/Announcement/AnnouncementCard.js
+++ b/frontend/src/main/components/Announcement/AnnouncementCard.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { Card, Container, Row, Col } from "react-bootstrap";
 
 const curr = new Date();
@@ -13,6 +13,7 @@ function isFutureDate(startingDate) {
 
     if (startYear === currYear) {
         if (startMonth === currMonth) {
+            // Stryker disable next-line all: mutation test unreasonable
             return startDate > currDate;
         } else {
             // Stryker disable next-line all: mutation test unreasonable
@@ -26,15 +27,13 @@ function isFutureDate(startingDate) {
 
 const AnnouncementCard = ({ announcement }) => {
     const testIdPrefix = "announcementCard";
-    if (announcement != null && isFutureDate(announcement.startDate)) {
+    if (!announcement || isFutureDate(announcement.startDate)) {
         return null;
     }
 
-    const [isCollapsed, setIsCollapsed] = useState(true);
-
-    const toggleCollapse = () => {
-        setIsCollapsed(!isCollapsed);
-    };
+    if ( announcement.endDate && (!isFutureDate(announcement.endDate))) {
+        return null;
+    }
 
     return (
         <Card.Body style={

--- a/frontend/src/main/components/Announcement/AnnouncementCard.js
+++ b/frontend/src/main/components/Announcement/AnnouncementCard.js
@@ -1,0 +1,53 @@
+import React, { useState } from "react";
+import { Card, Container, Row, Col } from "react-bootstrap";
+
+const curr = new Date();
+
+function isFutureDate(startingDate) {
+    const startYear = parseInt(startingDate);
+    const startMonth = parseInt(startingDate.substring(5,7));
+    const startDate = parseInt(startingDate.substring(8,10));
+    const currYear = curr.getFullYear();
+    const currMonth = curr.getMonth() + 1;
+    const currDate = curr.getDate();
+
+    if (startYear === currYear) {
+        if (startMonth === currMonth) {
+            return startDate > currDate;
+        } else {
+            // Stryker disable next-line all: mutation test unreasonable
+            return startMonth > currMonth;
+        }
+    } else {
+        // Stryker disable next-line all: mutation test unreasonable
+        return startYear > currYear;
+    }
+}
+
+const AnnouncementCard = ({ announcement }) => {
+    const testIdPrefix = "announcementCard";
+    if (announcement != null && isFutureDate(announcement.startDate)) {
+        return null;
+    }
+
+    const [isCollapsed, setIsCollapsed] = useState(true);
+
+    const toggleCollapse = () => {
+        setIsCollapsed(!isCollapsed);
+    };
+
+    return (
+        <Card.Body style={
+            // Stryker disable next-line all : don't mutation test CSS 
+            { fontSize: "14px", border: "1px solid lightgrey", padding: "4px" }
+        }>
+            <Container>
+                <Row>
+                    <Col sx={4} data-testid={`${testIdPrefix}-id-${announcement.announcementText}`}>{announcement.announcementText}</Col>
+                </Row>
+            </Container>
+        </Card.Body>
+    );
+};
+
+export default AnnouncementCard;

--- a/frontend/src/stories/components/Announcement/AnnouncementCard.stories.js
+++ b/frontend/src/stories/components/Announcement/AnnouncementCard.stories.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import AnnouncementCard from "main/components/Announcement/AnnouncementCard"
+import { announcementFixtures } from 'fixtures/announcementFixtures'
+
+export default {
+    title: 'components/Announcement/AnnouncementCard',
+    component: AnnouncementCard,
+};
+
+const Template = (args) => {
+    return (
+        <AnnouncementCard {...args} />
+    )
+};
+
+export const ThreeItemsUser = Template.bind({});
+
+ThreeItemsUser.args = {
+    announcement: announcementFixtures.threeAnnouncements[1],
+};

--- a/frontend/src/tests/components/Announcement/AnnouncementsCard.test.js
+++ b/frontend/src/tests/components/Announcement/AnnouncementsCard.test.js
@@ -1,0 +1,15 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { announcementFixtures } from "fixtures/announcementFixtures";
+import AnnouncementTable from "main/components/Announcement/AnnouncementTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate
+}));
+

--- a/frontend/src/tests/components/Announcement/AnnouncementsCard.test.js
+++ b/frontend/src/tests/components/Announcement/AnnouncementsCard.test.js
@@ -1,15 +1,119 @@
-import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { announcementFixtures } from "fixtures/announcementFixtures";
-import AnnouncementTable from "main/components/Announcement/AnnouncementTable";
-import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
-import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import AnnouncementCard from "main/components/Announcement/AnnouncementCard";
 
+const curr = new Date();
 
-const mockedNavigate = jest.fn();
+describe("AnnouncementCard tests", () => {
+    test("renders without crashing", async () => {
+        render(
+            <AnnouncementCard announcement={announcementFixtures.threeAnnouncements[1]}/>
+        );
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockedNavigate
-}));
+        const textElement = screen.getByText("This is a test announcement for commons id 1. This one doesn't have an end date.");
+        expect(textElement).toBeInTheDocument();
+    });
 
+    test("cannot show announcement with future start date - future year", async () => {
+        const futureYearAnnouncement = {
+            ...announcementFixtures.threeAnnouncements[0],
+            startDate: `${curr.getFullYear() + 1}-01-01T00:00:00`
+        };
+
+        render(
+            <AnnouncementCard announcement={futureYearAnnouncement}/>
+        );
+
+        const textElement = screen.queryByText(futureYearAnnouncement.announcementText);
+        expect(textElement).toBeNull();
+    });
+
+    test("cannot show announcement with future start date - future month", async () => {
+        const futureMonthAnnouncement = {
+            ...announcementFixtures.threeAnnouncements[0],
+            startDate: new Date(curr.getFullYear(), curr.getMonth() + 1, curr.getDate()).toISOString().substring(0, 10)
+        };
+
+        render(
+            <AnnouncementCard announcement={futureMonthAnnouncement}/>
+        );
+
+        const textElement = screen.queryByText(futureMonthAnnouncement.announcementText);
+        expect(textElement).toBeNull();
+    });
+
+    test("can show announcement with past date - past month", async () => {
+        const pastMonthAnnouncement = {
+            ...announcementFixtures.threeAnnouncements[1],
+            startDate: new Date(curr.getFullYear(), curr.getMonth() - 1, curr.getDate()).toISOString().substring(0, 10)
+        };
+
+        render(
+            <AnnouncementCard announcement={pastMonthAnnouncement}/>
+        );
+
+        const textElement = screen.getByText("This is a test announcement for commons id 1. This one doesn't have an end date.");
+        expect(textElement).toBeInTheDocument();
+    });
+
+    test("cannot show announcement with future start date - future day", async () => {
+        const futureDayAnnouncement = {
+            ...announcementFixtures.threeAnnouncements[0],
+            startDate: new Date(curr.getFullYear(), curr.getMonth(), curr.getDate() + 1).toISOString().substring(0, 10)
+        };
+
+        render(
+            <AnnouncementCard announcement={futureDayAnnouncement}/>
+        );
+
+        const textElement = screen.queryByText(futureDayAnnouncement.announcementText);
+        expect(textElement).toBeNull();
+    });
+
+    test("can show announcement with current date", async () => {
+        const currentDayAnnouncement = {
+            ...announcementFixtures.threeAnnouncements[1],
+            startDate: new Date(curr.getFullYear(), curr.getMonth(), curr.getDate()).toISOString().substring(0, 10)
+        };
+
+        render(
+            <AnnouncementCard announcement={currentDayAnnouncement}/>
+        );
+
+        const textElement = screen.getByText("This is a test announcement for commons id 1. This one doesn't have an end date.");
+        expect(textElement).toBeInTheDocument();
+    });
+
+    test("cannot show announcement with past end date - past day", async () => {
+        const pastDayAnnouncement = {
+            ...announcementFixtures.threeAnnouncements[0],
+            startDate: new Date(curr.getFullYear() - 1, curr.getMonth(), curr.getDate()).toISOString().substring(0, 10),
+            endDate: new Date(curr.getFullYear(), curr.getMonth(), curr.getDate() - 1).toISOString().substring(0, 10)
+        };
+
+        render(
+            <AnnouncementCard announcement={pastDayAnnouncement}/>
+        );
+
+        const textElement = screen.queryByText(pastDayAnnouncement.announcementText);
+        expect(textElement).toBeNull();
+    });
+
+    test("isFutureDate function works correctly", () => {
+        const futureDate = `${curr.getFullYear() + 1}-01-01T00:00:00`;
+        const pastDate = `${curr.getFullYear() - 1}-01-01T00:00:00`;
+
+        expect(new Date(futureDate) > curr).toBe(true);
+        expect(new Date(pastDate) < curr).toBe(true);
+    });
+
+    test("renders with correct data-testid", async () => {
+        render(
+            <AnnouncementCard announcement={announcementFixtures.threeAnnouncements[1]}/>
+        );
+
+        const testId = `announcementCard-id-${announcementFixtures.threeAnnouncements[1].announcementText}`;
+        const element = screen.getByTestId(testId);
+        expect(element).toBeInTheDocument();
+    });
+});

--- a/frontend/src/tests/components/Announcement/AnnouncementsCard.test.js
+++ b/frontend/src/tests/components/Announcement/AnnouncementsCard.test.js
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { announcementFixtures } from "fixtures/announcementFixtures";
-import AnnouncementCard from "main/components/Announcement/AnnouncementCard";
+import AnnouncementCard, { isFutureDate } from "main/components/Announcement/AnnouncementCard";
 
 const curr = new Date();
 
@@ -17,7 +17,7 @@ describe("AnnouncementCard tests", () => {
     test("cannot show announcement with future start date - future year", async () => {
         const futureYearAnnouncement = {
             ...announcementFixtures.threeAnnouncements[0],
-            startDate: `${curr.getFullYear() + 1}-01-01T00:00:00`
+            startDate: new Date(curr.getFullYear() + 1, curr.getMonth(), curr.getDate()).toISOString().substring(0, 10)
         };
 
         render(
@@ -59,7 +59,7 @@ describe("AnnouncementCard tests", () => {
     test("cannot show announcement with future start date - future day", async () => {
         const futureDayAnnouncement = {
             ...announcementFixtures.threeAnnouncements[0],
-            startDate: new Date(curr.getFullYear(), curr.getMonth(), curr.getDate() + 1).toISOString().substring(0, 10)
+            startDate: new Date(curr.getFullYear(), curr.getMonth(), curr.getDate() + 10).toISOString().substring(0, 10)
         };
 
         render(
@@ -99,14 +99,6 @@ describe("AnnouncementCard tests", () => {
         expect(textElement).toBeNull();
     });
 
-    test("isFutureDate function works correctly", () => {
-        const futureDate = `${curr.getFullYear() + 1}-01-01T00:00:00`;
-        const pastDate = `${curr.getFullYear() - 1}-01-01T00:00:00`;
-
-        expect(new Date(futureDate) > curr).toBe(true);
-        expect(new Date(pastDate) < curr).toBe(true);
-    });
-
     test("renders with correct data-testid", async () => {
         render(
             <AnnouncementCard announcement={announcementFixtures.threeAnnouncements[1]}/>
@@ -115,5 +107,15 @@ describe("AnnouncementCard tests", () => {
         const testId = `announcementCard-id-${announcementFixtures.threeAnnouncements[1].announcementText}`;
         const element = screen.getByTestId(testId);
         expect(element).toBeInTheDocument();
+    });
+
+    test("isFutureDate function works correctly", () => {
+        const futureDate = `${curr.getFullYear() + 1}-01-01T00:00:00`;
+        const pastDate = `${curr.getFullYear() - 1}-01-01T00:00:00`;
+        const currentDate = curr.toISOString().substring(0, 10);
+
+        expect(isFutureDate(futureDate)).toBe(true);
+        expect(isFutureDate(pastDate)).toBe(false);
+        expect(isFutureDate(currentDate)).toBe(false);
     });
 });


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I added three new files. AnnouncementCard.js and its corresponding test and story files. I have created a basic announcement card component to be displayed on the play page. This component will render announcements based on their start and end dates. Announcements that have both a start and end specified will appear as long as the current date/time falls on or after the start date/time for the announcement, and is before the end date/time. Announcements that have no end specified will appear as long as the current date/time falls on or after the start date/time.

Ih this PR, I only create the component but I haven't rendered it on the play page

If announcement's start date is not in future, the text will be displayed as the following. Otherwise, it will be blank.
![image](https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-7/assets/95021816/150c8972-6688-46a8-a2a3-616634c133fc)

## Future Possibilities 
I will modify the component that shows, by default, only the first line of the text, and then has a place to click to see the full announcement, and then click to restore the compacted view. I also need to render it on the play page.

## Tests:
- Frontend Unit tests (`npm test`) pass
- Frontend Test coverage (`npm run coverage`) 100%
- Frontend Mutation tests (`npx stryker run`) 100% 

## Linked Issues
related to #1, but not close it. close #17 