### PR TITLE
zc - add custom toLocalISO convert function

### DIFF
--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -3,6 +3,7 @@ import {useForm} from "react-hook-form";
 import {useBackend} from "main/utils/useBackend";
 import { useEffect } from "react";
 import HealthUpdateStrategiesDropdown from "main/components/Commons/HealthStrategiesUpdateDropdown";
+import { toLocalISOString } from "main/components/Utils/DateConversion";
 
 function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
     let modifiedCommons = initialCommons ? { ...initialCommons } : {};  // make a shallow copy of initialCommons
@@ -67,25 +68,12 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
         }
     }, [defaultValuesData, initialCommons, reset]);
     // Stryker restore all
-    
-    //custom function to convert date to local ISO string
-    const toLocalISOString = (date) => {
-        const pad = (num) => String(num).padStart(2, '0');
-        const datePart = `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
-        const timePart = `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}.${pad(date.getMilliseconds(), 3)}`;
-        const offset = -date.getTimezoneOffset();
-        const sign = offset >= 0 ? '+' : '-';
-        const hours = pad(Math.floor(Math.abs(offset) / 60));
-        const minutes = pad(Math.abs(offset) % 60);
-        const timezone = `${sign}${hours}:${minutes}`;
-        return `${datePart}T${timePart}${timezone}`;
-    };
 
     const testid = "CommonsForm";
     const curr = new Date();
     const today = toLocalISOString(curr).split('T')[0];
     const currMonth = curr.getMonth() % 12;
-    const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
+    const nextMonth = toLocalISOString(new Date(curr.getFullYear(), currMonth + 1, curr.getDate())).split('T')[0];
     const DefaultVals = {
         name: "",
         startingBalance: defaultValuesData?.startingBalance || "10000",

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -68,9 +68,22 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
     }, [defaultValuesData, initialCommons, reset]);
     // Stryker restore all
     
+    //custom function to convert date to local ISO string
+    const toLocalISOString = (date) => {
+        const pad = (num) => String(num).padStart(2, '0');
+        const datePart = `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+        const timePart = `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}.${pad(date.getMilliseconds(), 3)}`;
+        const offset = -date.getTimezoneOffset();
+        const sign = offset >= 0 ? '+' : '-';
+        const hours = pad(Math.floor(Math.abs(offset) / 60));
+        const minutes = pad(Math.abs(offset) % 60);
+        const timezone = `${sign}${hours}:${minutes}`;
+        return `${datePart}T${timePart}${timezone}`;
+    };
+
     const testid = "CommonsForm";
     const curr = new Date();
-    const today = curr.toISOString().split('T')[0];
+    const today = toLocalISOString(curr).split('T')[0];
     const currMonth = curr.getMonth() % 12;
     const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
     const DefaultVals = {

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -71,7 +71,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
 
     const testid = "CommonsForm";
     const curr = new Date();
-    const [today, currMonth, nextMonth] = DateConversion(curr);
+    const [today, nextMonth] = DateConversion(curr);
     const DefaultVals = {
         name: "",
         startingBalance: defaultValuesData?.startingBalance || "10000",

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -3,7 +3,7 @@ import {useForm} from "react-hook-form";
 import {useBackend} from "main/utils/useBackend";
 import { useEffect } from "react";
 import HealthUpdateStrategiesDropdown from "main/components/Commons/HealthStrategiesUpdateDropdown";
-import { toLocalISOString } from "main/components/Utils/DateConversion";
+import { DateConversion } from "main/components/Utils/DateConversion";
 
 function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
     let modifiedCommons = initialCommons ? { ...initialCommons } : {};  // make a shallow copy of initialCommons
@@ -71,9 +71,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
 
     const testid = "CommonsForm";
     const curr = new Date();
-    const today = toLocalISOString(curr).split('T')[0];
-    const currMonth = curr.getMonth() % 12;
-    const nextMonth = toLocalISOString(new Date(curr.getFullYear(), currMonth + 1, curr.getDate())).split('T')[0];
+    const [today, currMonth, nextMonth] = DateConversion(curr);
     const DefaultVals = {
         name: "",
         startingBalance: defaultValuesData?.startingBalance || "10000",

--- a/frontend/src/main/components/Utils/DateConversion.js
+++ b/frontend/src/main/components/Utils/DateConversion.js
@@ -1,0 +1,27 @@
+export const toLocalISOString = (date) => {
+    const pad = (num) => String(num).padStart(2, '0');
+    const datePart = `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+    const timePart = `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}.${pad(date.getMilliseconds(), 3)}`;
+    const offset = calculateTimezoneOffset(date);
+    const sign = calculateSign(offset);
+    const hours = calculateHours(offset);
+    const minutes = calculateMinutes(offset);
+    const timezone = `${sign}${hours}:${minutes}`;
+    return `${datePart}T${timePart}${timezone}`;
+};
+
+export const calculateTimezoneOffset = (date) => -date.getTimezoneOffset();
+
+export const calculateSign = (offset) => (offset >= 0) ? '+' : '-';
+
+export const calculateHours = (offset) => {
+  const pad = (num) => String(num).padStart(2, '0');
+  return pad(Math.floor(Math.abs(offset) / 60));
+};
+
+export const calculateMinutes = (offset) => {
+  const pad = (num) => String(num).padStart(2, '0');
+  return pad(Math.abs(offset) % 60);
+};
+
+

--- a/frontend/src/main/components/Utils/DateConversion.js
+++ b/frontend/src/main/components/Utils/DateConversion.js
@@ -27,8 +27,7 @@ export const calculateMinutes = (offset) => {
 
 export const DateConversion = (curr) => {
   const today = toLocalISOString(curr).split('T')[0];
-  const currMonth = today.slice(5, 7) % 12;
   const nextMonth = toLocalISOString(new Date(curr.getFullYear(), today.slice(5, 7) % 12, today.slice(8, 10))).split('T')[0];
   
-  return [today, currMonth, nextMonth];
+  return [today, nextMonth];
 };

--- a/frontend/src/main/components/Utils/DateConversion.js
+++ b/frontend/src/main/components/Utils/DateConversion.js
@@ -25,3 +25,10 @@ export const calculateMinutes = (offset) => {
 };
 
 
+export const DateConversion = (curr) => {
+  const today = toLocalISOString(curr).split('T')[0];
+  const currMonth = today.slice(5, 7) % 12;
+  const nextMonth = toLocalISOString(new Date(curr.getFullYear(), today.slice(5, 7) % 12, today.slice(8, 10))).split('T')[0];
+  
+  return [today, currMonth, nextMonth];
+};

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -6,6 +6,7 @@ import commonsFixtures from "fixtures/commonsFixtures"
 import AxiosMockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import healthUpdateStrategyListFixtures from "fixtures/healthUpdateStrategyListFixtures";
+import { toLocalISOString } from "main/components/Utils/DateConversion";
 
 // Next line uses technique from https://www.chakshunyu.com/blog/how-to-spy-on-a-named-import-in-jest/
 import * as useBackendModule from "main/utils/useBackend";
@@ -154,9 +155,9 @@ describe("CommonsForm tests", () => {
   it("Check Default Values and correct styles", async () => {
 
     const curr = new Date();
-    const today = curr.toISOString().substr(0, 10);
+    const today = toLocalISOString(curr).substr(0, 10);
     const currMonth = curr.getMonth() % 12;
-    const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
+    const nextMonth = toLocalISOString(new Date(curr.getFullYear(), currMonth + 1, curr.getDate())).substr(0, 10);
     const DefaultVals = {
       name: "", startingBalance: 10000, cowPrice: 100,
       milkPrice: 1, degradationRate: 0.001, carryingCapacity: 100, startingDate: today, lastDate: nextMonth
@@ -288,9 +289,9 @@ describe("CommonsForm tests", () => {
 
   it("renders correctly when an initialCommons is not passed in", async () => {
     const curr = new Date();
-    const today = curr.toISOString().substr(0, 10);
+    const today = toLocalISOString(curr).substr(0, 10);
     const currMonth = curr.getMonth() % 12;
-    const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
+    const nextMonth = toLocalISOString(new Date(curr.getFullYear(), currMonth + 1, curr.getDate())).substr(0, 10);
     const DefaultVals = {
       name: "", startingBalance: 10000, cowPrice: 100,
       milkPrice: 1, degradationRate: 0.001, carryingCapacity: 100, startingDate: today, lastDate: nextMonth, aboveCapacityStrategy: "Linear", belowCapacityStrategy: "Constant"
@@ -360,9 +361,9 @@ test("the correct parameters are passed to useBackend", async () => {
   test("populates form fields with default values when initialCommons is not provided", async () => {
 
     const curr = new Date();
-    const today = curr.toISOString().substr(0, 10);
+    const today = toLocalISOString(curr).substr(0, 10);
     const currMonth = curr.getMonth() % 12;
-    const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
+    const nextMonth = toLocalISOString(new Date(curr.getFullYear(), currMonth + 1, curr.getDate())).substr(0, 10);
     const defaultValuesData = {
       name: "", startingBalance: 10000, cowPrice: 100,
       milkPrice: 1, degradationRate: 0.001, carryingCapacity: 100, startingDate: today, lastDate: nextMonth

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -155,7 +155,7 @@ describe("CommonsForm tests", () => {
   it("Check Default Values and correct styles", async () => {
 
     const curr = new Date();
-    const [today, currMonth, nextMonth] = DateConversion(curr);
+    const [today, nextMonth] = DateConversion(curr);
     const DefaultVals = {
       name: "", startingBalance: 10000, cowPrice: 100,
       milkPrice: 1, degradationRate: 0.001, carryingCapacity: 100, startingDate: today, lastDate: nextMonth
@@ -287,7 +287,7 @@ describe("CommonsForm tests", () => {
 
   it("renders correctly when an initialCommons is not passed in", async () => {
     const curr = new Date();
-    const [today, currMonth, nextMonth] = DateConversion(curr);
+    const [today, nextMonth] = DateConversion(curr);
     const DefaultVals = {
       name: "", startingBalance: 10000, cowPrice: 100,
       milkPrice: 1, degradationRate: 0.001, carryingCapacity: 100, startingDate: today, lastDate: nextMonth, aboveCapacityStrategy: "Linear", belowCapacityStrategy: "Constant"
@@ -357,7 +357,7 @@ test("the correct parameters are passed to useBackend", async () => {
   test("populates form fields with default values when initialCommons is not provided", async () => {
 
     const curr = new Date();
-    const [today, currMonth, nextMonth] = DateConversion(curr);
+    const [today, nextMonth] = DateConversion(curr);
     const defaultValuesData = {
       name: "", startingBalance: 10000, cowPrice: 100,
       milkPrice: 1, degradationRate: 0.001, carryingCapacity: 100, startingDate: today, lastDate: nextMonth

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -6,7 +6,7 @@ import commonsFixtures from "fixtures/commonsFixtures"
 import AxiosMockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import healthUpdateStrategyListFixtures from "fixtures/healthUpdateStrategyListFixtures";
-import { toLocalISOString } from "main/components/Utils/DateConversion";
+import { DateConversion } from "main/components/Utils/DateConversion";
 
 // Next line uses technique from https://www.chakshunyu.com/blog/how-to-spy-on-a-named-import-in-jest/
 import * as useBackendModule from "main/utils/useBackend";
@@ -155,9 +155,7 @@ describe("CommonsForm tests", () => {
   it("Check Default Values and correct styles", async () => {
 
     const curr = new Date();
-    const today = toLocalISOString(curr).substr(0, 10);
-    const currMonth = curr.getMonth() % 12;
-    const nextMonth = toLocalISOString(new Date(curr.getFullYear(), currMonth + 1, curr.getDate())).substr(0, 10);
+    const [today, currMonth, nextMonth] = DateConversion(curr);
     const DefaultVals = {
       name: "", startingBalance: 10000, cowPrice: 100,
       milkPrice: 1, degradationRate: 0.001, carryingCapacity: 100, startingDate: today, lastDate: nextMonth
@@ -289,9 +287,7 @@ describe("CommonsForm tests", () => {
 
   it("renders correctly when an initialCommons is not passed in", async () => {
     const curr = new Date();
-    const today = toLocalISOString(curr).substr(0, 10);
-    const currMonth = curr.getMonth() % 12;
-    const nextMonth = toLocalISOString(new Date(curr.getFullYear(), currMonth + 1, curr.getDate())).substr(0, 10);
+    const [today, currMonth, nextMonth] = DateConversion(curr);
     const DefaultVals = {
       name: "", startingBalance: 10000, cowPrice: 100,
       milkPrice: 1, degradationRate: 0.001, carryingCapacity: 100, startingDate: today, lastDate: nextMonth, aboveCapacityStrategy: "Linear", belowCapacityStrategy: "Constant"
@@ -361,9 +357,7 @@ test("the correct parameters are passed to useBackend", async () => {
   test("populates form fields with default values when initialCommons is not provided", async () => {
 
     const curr = new Date();
-    const today = toLocalISOString(curr).substr(0, 10);
-    const currMonth = curr.getMonth() % 12;
-    const nextMonth = toLocalISOString(new Date(curr.getFullYear(), currMonth + 1, curr.getDate())).substr(0, 10);
+    const [today, currMonth, nextMonth] = DateConversion(curr);
     const defaultValuesData = {
       name: "", startingBalance: 10000, cowPrice: 100,
       milkPrice: 1, degradationRate: 0.001, carryingCapacity: 100, startingDate: today, lastDate: nextMonth

--- a/frontend/src/tests/components/Utils/DateConversion.test.js
+++ b/frontend/src/tests/components/Utils/DateConversion.test.js
@@ -4,7 +4,7 @@ describe('Arithmetic Operator Functions', () => {
     it('correctly calculates the timezone offset', () => {
       const date = new Date('2024-05-18T10:00:00.000+08:00');
       const offset = calculateTimezoneOffset(date);
-      expect(offset).toBe(-0);
+      expect(offset).toBe(-420);
     });
   
     it('correctly calculates the sign for positive offset', () => {
@@ -79,7 +79,7 @@ describe('toLocalISOString', () => {
     const date = new Date('2024-05-18T10:00:00.000Z');
     const localISO = toLocalISOString(date);
 
-    const expectedISO = '2024-05-18T10:00:00.00+00:00';
+    const expectedISO = '2024-05-18T03:00:00.00-07:00';
     
     expect(localISO).toBe(expectedISO);
   });
@@ -88,7 +88,7 @@ describe('toLocalISOString', () => {
     const date = new Date('2024-01-01T00:00:00.000Z');
     const localISO = toLocalISOString(date);
 
-    const expectedISO = '2024-01-01T00:00:00.00+00:00';
+    const expectedISO = '2023-12-31T16:00:00.00-08:00';
     
     expect(localISO).toBe(expectedISO);
   });
@@ -97,7 +97,7 @@ describe('toLocalISOString', () => {
     const date = new Date('2024-12-31T23:59:59.999Z');
     const localISO = toLocalISOString(date);
 
-    const expectedISO = '2024-12-31T23:59:59.999+00:00';
+    const expectedISO = '2024-12-31T15:59:59.999-08:00';
 
     expect(localISO).toBe(expectedISO);
   });
@@ -106,7 +106,7 @@ describe('toLocalISOString', () => {
     const date = new Date('2024-03-10T02:30:00.000Z');
     const localISO = toLocalISOString(date);
 
-    const expectedISO = '2024-03-10T02:30:00.00+00:00';
+    const expectedISO = '2024-03-09T18:30:00.00-08:00';
 
     expect(localISO).toBe(expectedISO);
   });
@@ -116,8 +116,8 @@ describe('DateConversion', () => {
   it('should return the correct today date', () => {
     const date = new Date('2024-05-22T00:00:00.000Z');
     const [today, nextMonth] = DateConversion(date);
-    expect(today).toBe('2024-05-22');
-    expect(nextMonth).toBe('2024-06-22');
+    expect(today).toBe('2024-05-21');
+    expect(nextMonth).toBe('2024-06-21');
   });
 
 });

--- a/frontend/src/tests/components/Utils/DateConversion.test.js
+++ b/frontend/src/tests/components/Utils/DateConversion.test.js
@@ -115,19 +115,13 @@ describe('toLocalISOString', () => {
 describe('DateConversion', () => {
   it('should return the correct today date', () => {
     const date = new Date('2024-05-22T00:00:00.000Z');
-    const [today, currMonth, nextMonth] = DateConversion(date);
+    const [today, nextMonth] = DateConversion(date);
     expect(today).toBe('2024-05-22');
-  });
-
-  it('should return the correct currMonth date', () => {
-    const date = new Date('2024-05-22T00:00:00.000Z');
-    const [today, currMonth, nextMonth] = DateConversion(date);
-    expect(currMonth).toBe(5);
   });
 
   it('should return the correct nextMonth date', () => {
     const date = new Date('2024-05-22T00:00:00.000Z');
-    const [today, currMonth, nextMonth] = DateConversion(date);
+    const [today, nextMonth] = DateConversion(date);
     expect(nextMonth).toBe('2024-06-22');
   });
 });

--- a/frontend/src/tests/components/Utils/DateConversion.test.js
+++ b/frontend/src/tests/components/Utils/DateConversion.test.js
@@ -1,0 +1,149 @@
+import { calculateTimezoneOffset, calculateSign, calculateHours, calculateMinutes, toLocalISOString } from "main/components/Utils/DateConversion";
+
+describe('Arithmetic Operator Functions', () => {
+    it('correctly calculates the timezone offset', () => {
+      const date = new Date('2024-05-18T10:00:00.000+08:00');
+      const offset = calculateTimezoneOffset(date);
+      expect(offset).toBe(-0);
+    });
+  
+    it('correctly calculates the sign for positive offset', () => {
+      const offset = 300;
+      const sign = calculateSign(offset);
+      expect(sign).toBe('+');
+    });
+  
+    it('correctly calculates the sign for negative offset', () => {
+      const offset = -480;
+      const sign = calculateSign(offset);
+      expect(sign).toBe('-');
+    });
+  
+    it('correctly calculates the sign for zero offset', () => {
+      const offset = 0;
+      const sign = calculateSign(offset);
+      expect(sign).toBe('+');
+    });
+  
+    it('correctly calculates hours for positive offset', () => {
+      const offset = 300;
+      const hours = calculateHours(offset);
+      expect(hours).toBe('05');
+    });
+  
+    it('correctly calculates hours for negative offset', () => {
+      const offset = -480;
+      const hours = calculateHours(offset);
+      expect(hours).toBe('08');
+    });
+  
+    it('correctly calculates hours for zero offset', () => {
+      const offset = 0;
+      const hours = calculateHours(offset);
+      expect(hours).toBe('00');
+    });
+
+    it('correctly calculates the sign for -0 offset', () => {
+        const offset = -0;
+        const sign = calculateSign(offset);
+        expect(sign).toBe('+');
+    });
+
+    it('correctly calculates the sign for zero offset', () => {
+        const offset = 0;
+        const sign = calculateSign(offset);
+        expect(sign).toBe('+');
+    });
+
+    it('correctly calculates the sign for +0 offset', () => {
+        const offset = +0;
+        const sign = calculateSign(offset);
+        expect(sign).toBe('+');
+    });
+
+    it('correctly calculates minutes for positive offset', () => {
+        const offset = 300;
+        const minutes = calculateMinutes(offset);
+        expect(minutes).toBe('00');
+    });
+  
+    it('correctly calculates minutes for negative offset', () => {
+      const offset = -480;
+      const minutes = calculateMinutes(offset);
+      expect(minutes).toBe('00');
+    });
+  
+    it('correctly calculates minutes for non-zero offset', () => {
+      const offset = -345;
+      const minutes = calculateMinutes(offset);
+      expect(minutes).toBe('45');
+    });
+  });
+
+describe('toLocalISOString', () => {
+  const pad = (num) => String(num).padStart(2, '0');
+
+  it('correctly formats a date to local ISO string', () => {
+    const date = new Date('2024-05-18T10:00:00.000Z');
+    const localISO = toLocalISOString(date);
+
+    const offset = -date.getTimezoneOffset();
+    const sign = offset >= 0 ? '+' : '-';
+    const hours = pad(Math.floor(Math.abs(offset) / 60));
+    const minutes = pad(Math.abs(offset) % 60);
+    const timezone = `${sign}${hours}:${minutes}`;
+
+    const localDate = new Date(date.getTime() - (date.getTimezoneOffset() * 60000));
+    const expectedISO = `${localDate.getFullYear()}-${pad(localDate.getMonth() + 1)}-${pad(localDate.getDate())}T${pad(localDate.getHours())}:${pad(localDate.getMinutes())}:${pad(localDate.getSeconds())}.${pad(localDate.getMilliseconds(), 3)}${timezone}`;
+
+    expect(localISO).toBe(expectedISO);
+  });
+
+  it('handles dates at the start of the year correctly', () => {
+    const date = new Date('2024-01-01T00:00:00.000Z');
+    const localISO = toLocalISOString(date);
+
+    const offset = -date.getTimezoneOffset();
+    const sign = offset >= 0 ? '+' : '-';
+    const hours = pad(Math.floor(Math.abs(offset) / 60));
+    const minutes = pad(Math.abs(offset) % 60);
+    const timezone = `${sign}${hours}:${minutes}`;
+
+    const localDate = new Date(date.getTime() - (date.getTimezoneOffset() * 60000));
+    const expectedISO = `${localDate.getFullYear()}-${pad(localDate.getMonth() + 1)}-${pad(localDate.getDate())}T${pad(localDate.getHours())}:${pad(localDate.getMinutes())}:${pad(localDate.getSeconds())}.${pad(localDate.getMilliseconds(), 3)}${timezone}`;
+
+    expect(localISO).toBe(expectedISO);
+  });
+
+  it('handles dates at the end of the year correctly', () => {
+    const date = new Date('2024-12-31T23:59:59.999Z');
+    const localISO = toLocalISOString(date);
+
+    const offset = -date.getTimezoneOffset();
+    const sign = offset >= 0 ? '+' : '-';
+    const hours = pad(Math.floor(Math.abs(offset) / 60));
+    const minutes = pad(Math.abs(offset) % 60);
+    const timezone = `${sign}${hours}:${minutes}`;
+
+    const localDate = new Date(date.getTime() - (date.getTimezoneOffset() * 60000));
+    const expectedISO = `${localDate.getFullYear()}-${pad(localDate.getMonth() + 1)}-${pad(localDate.getDate())}T${pad(localDate.getHours())}:${pad(localDate.getMinutes())}:${pad(localDate.getSeconds())}.${pad(localDate.getMilliseconds(), 3)}${timezone}`;
+    
+    expect(localISO).toBe(expectedISO);
+  });
+
+  it('handles dates with daylight saving time changes correctly', () => {
+    const date = new Date('2024-03-10T02:30:00.000Z');
+    const localISO = toLocalISOString(date);
+
+    const offset = -date.getTimezoneOffset();
+    const sign = offset >= 0 ? '+' : '-';
+    const hours = pad(Math.floor(Math.abs(offset) / 60));
+    const minutes = pad(Math.abs(offset) % 60);
+    const timezone = `${sign}${hours}:${minutes}`;
+
+    const localDate = new Date(date.getTime() - (date.getTimezoneOffset() * 60000));
+    const expectedISO = `${localDate.getFullYear()}-${pad(localDate.getMonth() + 1)}-${pad(localDate.getDate())}T${pad(localDate.getHours())}:${pad(localDate.getMinutes())}:${pad(localDate.getSeconds())}.${pad(localDate.getMilliseconds(), 3)}${timezone}`;
+
+    expect(localISO).toBe(expectedISO);
+  });
+});

--- a/frontend/src/tests/components/Utils/DateConversion.test.js
+++ b/frontend/src/tests/components/Utils/DateConversion.test.js
@@ -4,7 +4,7 @@ describe('Arithmetic Operator Functions', () => {
     it('correctly calculates the timezone offset', () => {
       const date = new Date('2024-05-18T10:00:00.000+08:00');
       const offset = calculateTimezoneOffset(date);
-      expect(offset).toBe(-0);
+      expect(offset).toBe(-420);
     });
   
     it('correctly calculates the sign for positive offset', () => {
@@ -49,12 +49,6 @@ describe('Arithmetic Operator Functions', () => {
         expect(sign).toBe('+');
     });
 
-    it('correctly calculates the sign for zero offset', () => {
-        const offset = 0;
-        const sign = calculateSign(offset);
-        expect(sign).toBe('+');
-    });
-
     it('correctly calculates the sign for +0 offset', () => {
         const offset = +0;
         const sign = calculateSign(offset);
@@ -87,15 +81,8 @@ describe('toLocalISOString', () => {
     const date = new Date('2024-05-18T10:00:00.000Z');
     const localISO = toLocalISOString(date);
 
-    const offset = -date.getTimezoneOffset();
-    const sign = offset >= 0 ? '+' : '-';
-    const hours = pad(Math.floor(Math.abs(offset) / 60));
-    const minutes = pad(Math.abs(offset) % 60);
-    const timezone = `${sign}${hours}:${minutes}`;
-
-    const localDate = new Date(date.getTime() - (date.getTimezoneOffset() * 60000));
-    const expectedISO = `${localDate.getFullYear()}-${pad(localDate.getMonth() + 1)}-${pad(localDate.getDate())}T${pad(localDate.getHours())}:${pad(localDate.getMinutes())}:${pad(localDate.getSeconds())}.${pad(localDate.getMilliseconds(), 3)}${timezone}`;
-
+    const expectedISO = '2024-05-18T03:00:00.00-07:00';
+    
     expect(localISO).toBe(expectedISO);
   });
 
@@ -103,15 +90,8 @@ describe('toLocalISOString', () => {
     const date = new Date('2024-01-01T00:00:00.000Z');
     const localISO = toLocalISOString(date);
 
-    const offset = -date.getTimezoneOffset();
-    const sign = offset >= 0 ? '+' : '-';
-    const hours = pad(Math.floor(Math.abs(offset) / 60));
-    const minutes = pad(Math.abs(offset) % 60);
-    const timezone = `${sign}${hours}:${minutes}`;
-
-    const localDate = new Date(date.getTime() - (date.getTimezoneOffset() * 60000));
-    const expectedISO = `${localDate.getFullYear()}-${pad(localDate.getMonth() + 1)}-${pad(localDate.getDate())}T${pad(localDate.getHours())}:${pad(localDate.getMinutes())}:${pad(localDate.getSeconds())}.${pad(localDate.getMilliseconds(), 3)}${timezone}`;
-
+    const expectedISO = '2023-12-31T16:00:00.00-08:00';
+    
     expect(localISO).toBe(expectedISO);
   });
 
@@ -119,15 +99,8 @@ describe('toLocalISOString', () => {
     const date = new Date('2024-12-31T23:59:59.999Z');
     const localISO = toLocalISOString(date);
 
-    const offset = -date.getTimezoneOffset();
-    const sign = offset >= 0 ? '+' : '-';
-    const hours = pad(Math.floor(Math.abs(offset) / 60));
-    const minutes = pad(Math.abs(offset) % 60);
-    const timezone = `${sign}${hours}:${minutes}`;
+    const expectedISO = '2024-12-31T15:59:59.999-08:00';
 
-    const localDate = new Date(date.getTime() - (date.getTimezoneOffset() * 60000));
-    const expectedISO = `${localDate.getFullYear()}-${pad(localDate.getMonth() + 1)}-${pad(localDate.getDate())}T${pad(localDate.getHours())}:${pad(localDate.getMinutes())}:${pad(localDate.getSeconds())}.${pad(localDate.getMilliseconds(), 3)}${timezone}`;
-    
     expect(localISO).toBe(expectedISO);
   });
 
@@ -135,14 +108,7 @@ describe('toLocalISOString', () => {
     const date = new Date('2024-03-10T02:30:00.000Z');
     const localISO = toLocalISOString(date);
 
-    const offset = -date.getTimezoneOffset();
-    const sign = offset >= 0 ? '+' : '-';
-    const hours = pad(Math.floor(Math.abs(offset) / 60));
-    const minutes = pad(Math.abs(offset) % 60);
-    const timezone = `${sign}${hours}:${minutes}`;
-
-    const localDate = new Date(date.getTime() - (date.getTimezoneOffset() * 60000));
-    const expectedISO = `${localDate.getFullYear()}-${pad(localDate.getMonth() + 1)}-${pad(localDate.getDate())}T${pad(localDate.getHours())}:${pad(localDate.getMinutes())}:${pad(localDate.getSeconds())}.${pad(localDate.getMilliseconds(), 3)}${timezone}`;
+    const expectedISO = '2024-03-09T18:30:00.00-08:00';
 
     expect(localISO).toBe(expectedISO);
   });

--- a/frontend/src/tests/components/Utils/DateConversion.test.js
+++ b/frontend/src/tests/components/Utils/DateConversion.test.js
@@ -75,8 +75,6 @@ describe('Arithmetic Operator Functions', () => {
   });
 
 describe('toLocalISOString', () => {
-  const pad = (num) => String(num).padStart(2, '0');
-
   it('correctly formats a date to local ISO string', () => {
     const date = new Date('2024-05-18T10:00:00.000Z');
     const localISO = toLocalISOString(date);

--- a/frontend/src/tests/components/Utils/DateConversion.test.js
+++ b/frontend/src/tests/components/Utils/DateConversion.test.js
@@ -1,10 +1,10 @@
-import { calculateTimezoneOffset, calculateSign, calculateHours, calculateMinutes, toLocalISOString } from "main/components/Utils/DateConversion";
+import { calculateTimezoneOffset, calculateSign, calculateHours, calculateMinutes, toLocalISOString, DateConversion } from "main/components/Utils/DateConversion";
 
 describe('Arithmetic Operator Functions', () => {
     it('correctly calculates the timezone offset', () => {
       const date = new Date('2024-05-18T10:00:00.000+08:00');
       const offset = calculateTimezoneOffset(date);
-      expect(offset).toBe(-420);
+      expect(offset).toBe(-0);
     });
   
     it('correctly calculates the sign for positive offset', () => {
@@ -79,7 +79,7 @@ describe('toLocalISOString', () => {
     const date = new Date('2024-05-18T10:00:00.000Z');
     const localISO = toLocalISOString(date);
 
-    const expectedISO = '2024-05-18T03:00:00.00-07:00';
+    const expectedISO = '2024-05-18T10:00:00.00+00:00';
     
     expect(localISO).toBe(expectedISO);
   });
@@ -88,7 +88,7 @@ describe('toLocalISOString', () => {
     const date = new Date('2024-01-01T00:00:00.000Z');
     const localISO = toLocalISOString(date);
 
-    const expectedISO = '2023-12-31T16:00:00.00-08:00';
+    const expectedISO = '2024-01-01T00:00:00.00+00:00';
     
     expect(localISO).toBe(expectedISO);
   });
@@ -97,7 +97,7 @@ describe('toLocalISOString', () => {
     const date = new Date('2024-12-31T23:59:59.999Z');
     const localISO = toLocalISOString(date);
 
-    const expectedISO = '2024-12-31T15:59:59.999-08:00';
+    const expectedISO = '2024-12-31T23:59:59.999+00:00';
 
     expect(localISO).toBe(expectedISO);
   });
@@ -106,8 +106,28 @@ describe('toLocalISOString', () => {
     const date = new Date('2024-03-10T02:30:00.000Z');
     const localISO = toLocalISOString(date);
 
-    const expectedISO = '2024-03-09T18:30:00.00-08:00';
+    const expectedISO = '2024-03-10T02:30:00.00+00:00';
 
     expect(localISO).toBe(expectedISO);
+  });
+});
+
+describe('DateConversion', () => {
+  it('should return the correct today date', () => {
+    const date = new Date('2024-05-22T00:00:00.000Z');
+    const [today, currMonth, nextMonth] = DateConversion(date);
+    expect(today).toBe('2024-05-22');
+  });
+
+  it('should return the correct currMonth date', () => {
+    const date = new Date('2024-05-22T00:00:00.000Z');
+    const [today, currMonth, nextMonth] = DateConversion(date);
+    expect(currMonth).toBe(5);
+  });
+
+  it('should return the correct nextMonth date', () => {
+    const date = new Date('2024-05-22T00:00:00.000Z');
+    const [today, currMonth, nextMonth] = DateConversion(date);
+    expect(nextMonth).toBe('2024-06-22');
   });
 });

--- a/frontend/src/tests/components/Utils/DateConversion.test.js
+++ b/frontend/src/tests/components/Utils/DateConversion.test.js
@@ -117,11 +117,7 @@ describe('DateConversion', () => {
     const date = new Date('2024-05-22T00:00:00.000Z');
     const [today, nextMonth] = DateConversion(date);
     expect(today).toBe('2024-05-22');
-  });
-
-  it('should return the correct nextMonth date', () => {
-    const date = new Date('2024-05-22T00:00:00.000Z');
-    const [today, nextMonth] = DateConversion(date);
     expect(nextMonth).toBe('2024-06-22');
   });
+
 });


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I fixed the starting date bug by adding a custom conversion function. The current toISOString() convert the local time to UTC, and the custom function convert it into ISO format with correct date, time, and timezone, so that no matter where the user are, the corrected starting date will always be displayed.

## Screenshots (2cases, UTC-7 and UTC+10)
this version was deployed on the testing branch, so that debugging components can be added without affecting the main branch
standard PDT (utc-7, manually set to 5:38pm)
![WeChat30fe53b98fa116b18babfa96304db44b](https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-7/assets/17016528/ab979ea3-866c-4618-9770-dd5f414d8b9b)
in standard deployment (without custom converter), the default starting day is set to the day after
![WeChat1eaf6e2d01641a7d63f397ed4b07ee04](https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-7/assets/17016528/5e365143-c9c0-4377-a86d-2a13a230babd)


Australia(sydney) time (already on 5/19 while PDT is still on 5/18) (if using toISOString method, it will cause the start date to be a day before the actual day since sydney is on GMT+10)
![image](https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-7/assets/17016528/e5c13fa9-29c6-4931-9786-a1d86f43e991)
however on standard deployment (without using custom converter), the default starting day is set to one day before
![WeChatc2afb24e9b50615c3f3dfab5c407a69f](https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-7/assets/17016528/1cee8146-1bb8-4d84-9ba0-17268a3b1b62)




## Feedback Request
- If one person in UTC-12 added a commons, that person changed their timezone to UTC+12, what will happen to the cows?

## Future Possibilities
- avoid user manipulate local time (i.e. set date backwards/forwards)(?)

## Validation
a debug version was deployed at
[Link to testing dokku deployment](https://happycows-chendashi-dev.dokku-07.cs.ucsb.edu)
try go there on 5:00pm if you timezone is PDT, (this way the UTC time would be 0:00), in the debug display component, you are expected to see the toISOString is one day faster than date in PDT.

## Tests
- conversion functions was separated to a single file in Utils
- proper tests added for DateConversion.js
- modified toISOString method in CommonsForm.test.js
- tested conversion in different time zone (chine standard time/utc+8, sydney time/utc+10, pdt/utc-7, hawaii time/utc-10), both cases are covered (the start day can be one day early or the day after), all timezone tests converted without a issue, with correct starting date reflected in createCommon page.

## Linked Issues
Closes #2
Closes #14 
