### PR TITLE
na - started refactor of homepage

### DIFF
--- a/frontend/src/main/components/Commons/CommonsList.js
+++ b/frontend/src/main/components/Commons/CommonsList.js
@@ -7,24 +7,27 @@ const CommonsList = (props) => {
 
     return (
         <Card
+            data-testid="commonsList-background"
             style={
-                // Stryker disable next-line all: don't test CSS params
+                // Stryker disable all: don't test CSS params
                 { background: 'rgba(255, 255, 255, 0.7)', 
                     borderRadius: '10px', 
                     padding: '10px', 
                     backdropFilter: 'blur(10px)', 
                     WebkitBackdropFilter: 'blur(10px)'}
+                // Stryker restore all
             }
             className="my-3 border-0"
         >
             <Card.Title
                 data-testid="commonsList-title"
                 style={
-                    // Stryker disable next-line all: don't test CSS params
+                    // Stryker disable all: don't test CSS params
                     { fontSize: "35px",
                     fontWeight: "bold",
                     color: "#1E4D2B"
                     }
+                    // Stryker restore all
                 }
                 className="text-center my-3"
             >

--- a/frontend/src/main/components/Commons/CommonsList.js
+++ b/frontend/src/main/components/Commons/CommonsList.js
@@ -9,7 +9,11 @@ const CommonsList = (props) => {
         <Card
             style={
                 // Stryker disable next-line all: don't test CSS params
-                { opacity: ".9" }
+                { background: 'rgba(255, 255, 255, 0.7)', 
+                    borderRadius: '10px', 
+                    padding: '10px', 
+                    backdropFilter: 'blur(10px)', 
+                    WebkitBackdropFilter: 'blur(10px)'}
             }
             className="my-3 border-0"
         >

--- a/frontend/src/main/components/Commons/CommonsList.js
+++ b/frontend/src/main/components/Commons/CommonsList.js
@@ -17,7 +17,10 @@ const CommonsList = (props) => {
                 data-testid="commonsList-title"
                 style={
                     // Stryker disable next-line all: don't test CSS params
-                    { fontSize: "35px" }
+                    { fontSize: "35px",
+                    fontWeight: "bold",
+                    color: "#1E4D2B"
+                    }
                 }
                 className="text-center my-3"
             >

--- a/frontend/src/main/pages/HomePage.css
+++ b/frontend/src/main/pages/HomePage.css
@@ -1,7 +1,12 @@
 .new-title{
-  font-size: 50px;
-  color: #0e442d;
-  font-weight: bold;
+    font-size: 50px;
+    color: #0e442d;
+    font-weight: bold;
+    background: rgba(255, 255, 255, 0.1); 
+    border-radius: 10px; 
+    padding: 10px; 
+    backdrop-filter: blur(10px); 
+    -webkit-backdrop-filter: blur(10px); 
 }
 
 .subtitle{

--- a/frontend/src/main/pages/HomePage.css
+++ b/frontend/src/main/pages/HomePage.css
@@ -2,7 +2,7 @@
     font-size: 50px;
     color: #0e442d;
     font-weight: bold;
-    background: rgba(255, 255, 255, 0.9); 
+    background: rgba(255, 255, 255, 0.7); 
     border-radius: 10px; 
     padding: 10px; 
     backdrop-filter: blur(10px); 

--- a/frontend/src/main/pages/HomePage.css
+++ b/frontend/src/main/pages/HomePage.css
@@ -2,7 +2,7 @@
     font-size: 50px;
     color: #0e442d;
     font-weight: bold;
-    background: rgba(255, 255, 255, 0.1); 
+    background: rgba(255, 255, 255, 0.9); 
     border-radius: 10px; 
     padding: 10px; 
     backdrop-filter: blur(10px); 

--- a/frontend/src/main/pages/HomePage.css
+++ b/frontend/src/main/pages/HomePage.css
@@ -22,16 +22,11 @@
   margin-top: 50px;
 }
 
-.homePage-join{
+.homePage-box{
   display: flex;
   justify-content: center;
   margin-top: 50px;
-}
-
-.homePage-visit{
-  display: flex;
-  justify-content: center;
-  margin-top: 50px;
+  max-width: max-content;
 }
 
 @keyframes textclip {

--- a/frontend/src/main/pages/HomePage.css
+++ b/frontend/src/main/pages/HomePage.css
@@ -13,6 +13,7 @@
     backdrop-filter: blur(10px); 
     -webkit-backdrop-filter: blur(10px); 
     display: inline-block;
+    margin-bottom: 0px;
 }
 
 .subtitle{
@@ -24,14 +25,13 @@
 .homePage-boxes{
   display: flex;
   justify-content: space-around;
-  margin-top: 50px;
   gap: 20px;
 }
 
 .homePage-box{
   display: flex;
   justify-content: center;
-  margin-top: 50px;
+  margin-top: 20px;
   flex: 1;
 }
 

--- a/frontend/src/main/pages/HomePage.css
+++ b/frontend/src/main/pages/HomePage.css
@@ -1,3 +1,8 @@
+.title-box{
+    display: flex;
+    justify-content: center;
+}
+
 .new-title{
     font-size: 50px;
     color: #0e442d;

--- a/frontend/src/main/pages/HomePage.css
+++ b/frontend/src/main/pages/HomePage.css
@@ -1,24 +1,31 @@
-.animate-charcter
-{
-  background-image: linear-gradient(
-    -225deg,
-    #b72525 0%,
-    #e87902 29%,
-    #667503 67%,
-    #04a617 100%
-  );
-
-  background-size: auto auto;
-  background-clip: border-box;
-  background-size: 200% auto;
-  color: #0e442d;
-  background-clip: text;
-  text-fill-color: transparent;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  animation: textclip 2s linear infinite;
-  display: inline-block;
+.new-title{
   font-size: 50px;
+  color: #0e442d;
+  font-weight: bold;
+}
+
+.subtitle{
+  font-size: 20px;
+  color: #0e442d;
+  font-weight: bold;
+}
+
+.homePage-boxes{
+  display: flex;
+  justify-content: space-around;
+  margin-top: 50px;
+}
+
+.homePage-join{
+  display: flex;
+  justify-content: center;
+  margin-top: 50px;
+}
+
+.homePage-visit{
+  display: flex;
+  justify-content: center;
+  margin-top: 50px;
 }
 
 @keyframes textclip {

--- a/frontend/src/main/pages/HomePage.css
+++ b/frontend/src/main/pages/HomePage.css
@@ -7,6 +7,7 @@
     padding: 10px; 
     backdrop-filter: blur(10px); 
     -webkit-backdrop-filter: blur(10px); 
+    display: inline-block;
 }
 
 .subtitle{

--- a/frontend/src/main/pages/HomePage.css
+++ b/frontend/src/main/pages/HomePage.css
@@ -20,13 +20,14 @@
   display: flex;
   justify-content: space-around;
   margin-top: 50px;
+  gap: 20px;
 }
 
 .homePage-box{
   display: flex;
   justify-content: center;
   margin-top: 50px;
-  max-width: max-content;
+  flex: 1;
 }
 
 @keyframes textclip {

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -70,10 +70,10 @@ export default function HomePage({hour=null}) {
         <Container>
           <Row>
             <div className="homePage-boxes">
-              <div className="homePage-visit">
+              <div className="homePage-box">
                 <Col sm><CommonsList commonList={commonsJoined} title="Visit A Commons" buttonText={"Visit"} buttonLink={visitButtonClick} /></Col>
               </div>
-              <div className="homePage-join">
+              <div className="homePage-box">
                 <Col sm><CommonsList commonList={commonsNotJoinedList} title="Join A New Commons" buttonText={"Join"} buttonLink={mutation.mutate} /></Col>
               </div>
             </div>

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -66,7 +66,7 @@ export default function HomePage({hour=null}) {
   return (
     <div data-testid={"HomePage-main-div"} style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
       <BasicLayout>
-        <div className="title-box">
+        <div data-testid= {"HomePage-intro-card"} className="title-box">
           <h1 data-testid="homePage-title" className="new-title" >Howdy Farmer {firstName}!</h1>
         </div>
         <Container>

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { Card, Container, Row, Col } from "react-bootstrap";
+import { Container, Row, Col } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
@@ -66,15 +66,17 @@ export default function HomePage({hour=null}) {
   return (
     <div data-testid={"HomePage-main-div"} style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
       <BasicLayout>
-      <Card data-testid= {"HomePage-intro-card"} style={{opacity: ".9" }}>
-      <div className= "text-center border-0 my-3">
-              <h1 data-testid="homePage-title" className="animate-charcter" >Howdy Farmer {firstName}</h1>
-              </div>
-      </Card>
+        <h1 data-testid="homePage-title" className="new-title" >Howdy Farmer {firstName}!</h1>
         <Container>
           <Row>
-            <Col sm><CommonsList commonList={commonsJoined} title="Visit A Commons" buttonText={"Visit"} buttonLink={visitButtonClick} /></Col>
-            <Col sm><CommonsList commonList={commonsNotJoinedList} title="Join A New Commons" buttonText={"Join"} buttonLink={mutation.mutate} /></Col>
+            <div className="homePage-boxes">
+              <div className="homePage-visit">
+                <Col sm><CommonsList commonList={commonsJoined} title="Visit A Commons" buttonText={"Visit"} buttonLink={visitButtonClick} /></Col>
+              </div>
+              <div className="homePage-join">
+                <Col sm><CommonsList commonList={commonsNotJoinedList} title="Join A New Commons" buttonText={"Join"} buttonLink={mutation.mutate} /></Col>
+              </div>
+            </div>
           </Row>
         </Container>
       </BasicLayout>

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -66,7 +66,9 @@ export default function HomePage({hour=null}) {
   return (
     <div data-testid={"HomePage-main-div"} style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
       <BasicLayout>
-        <h1 data-testid="homePage-title" className="new-title" >Howdy Farmer {firstName}!</h1>
+        <div className="title-box">
+          <h1 data-testid="homePage-title" className="new-title" >Howdy Farmer {firstName}!</h1>
+        </div>
         <Container>
           <Row>
             <div className="homePage-boxes">

--- a/frontend/src/tests/components/Commons/CommonsList.test.js
+++ b/frontend/src/tests/components/Commons/CommonsList.test.js
@@ -99,6 +99,9 @@ describe("CommonsList tests", () => {
         expect(title).toBeInTheDocument();
         expect(typeof(title.textContent)).toBe('string');
         expect(title.textContent).toEqual('Join A New Commons');
+        // expect(title).toHaveStyle("font-size: 35px");
+        // expect(title).toHaveStyle("font-weight: bold");
+        // expect(title).toHaveStyle("color: #1E4D2B");
 
         const subtitle_name = screen.getByTestId("commonsList-default-message");
         expect(subtitle_name).toBeInTheDocument();
@@ -113,6 +116,9 @@ describe("CommonsList tests", () => {
         render(
             <CommonsList commonList={[]} buttonText = {"Visit"} title="Visit A Commons"/>
         );
+
+        const background = screen.getByTestId("commonsList-background");
+        expect(background).toBeInTheDocument();
 
         const title = screen.getByTestId("commonsList-title");
         expect(title).toBeInTheDocument();

--- a/frontend/src/tests/components/Commons/CommonsList.test.js
+++ b/frontend/src/tests/components/Commons/CommonsList.test.js
@@ -99,9 +99,6 @@ describe("CommonsList tests", () => {
         expect(title).toBeInTheDocument();
         expect(typeof(title.textContent)).toBe('string');
         expect(title.textContent).toEqual('Join A New Commons');
-        // expect(title).toHaveStyle("font-size: 35px");
-        // expect(title).toHaveStyle("font-weight: bold");
-        // expect(title).toHaveStyle("color: #1E4D2B");
 
         const subtitle_name = screen.getByTestId("commonsList-default-message");
         expect(subtitle_name).toBeInTheDocument();

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -50,7 +50,7 @@ describe("HomePage tests", () => {
         expect(typeof (title.textContent)).toBe('string');
         
         await waitFor(() => {
-            expect(title.textContent).toEqual('Howdy Farmer Phillip');
+            expect(title.textContent).toEqual('Howdy Farmer Phillip!');
         });
     });
 
@@ -71,7 +71,7 @@ describe("HomePage tests", () => {
         const title = screen.getByTestId("homePage-title");
         expect(title).toBeInTheDocument();
         expect(typeof (title.textContent)).toBe('string');
-        expect(title.textContent).toEqual('Howdy Farmer Phillip');
+        expect(title.textContent).toEqual('Howdy Farmer Phillip!');
     });
 
     test("expected CSS properties", () => {
@@ -85,7 +85,7 @@ describe("HomePage tests", () => {
             </QueryClientProvider>
         );        
         const title = screen.getByTestId("homePage-title");
-        expect(title).toHaveAttribute("class", "animate-charcter");
+        expect(title).toHaveAttribute("class", "new-title");
         });
 
     test("renders without crashing when lists are full", () => {
@@ -103,7 +103,7 @@ describe("HomePage tests", () => {
         const title = screen.getByTestId("homePage-title");
         expect(title).toBeInTheDocument();
         expect(typeof (title.textContent)).toBe('string');
-        expect(title.textContent).toEqual('Howdy Farmer Phillip');
+        expect(title.textContent).toEqual('Howdy Farmer Phillip!');
     });
 
     test("Redirects to the PlayPage when you click visit", async () => {
@@ -208,7 +208,7 @@ describe("HomePage tests", () => {
         expect(await screen.findByTestId("HomePage-intro-card")).toBeInTheDocument();
     
         const HomePageCard = screen.getByTestId("HomePage-intro-card");
-        expect(HomePageCard).toHaveStyle('opacity: .9;');       
+        expect(HomePageCard).toHaveAttribute("class", "title-box");
 
     });
 


### PR DESCRIPTION
## Overview
In this PR, I started the refactoring of the homepage by making the old components more visually appealing by changing the title, as well as the background of the boxes. In addition, I set the stage for more future refactoring by creating new styles in the homepage css file, and adding more divs in the homepage which more clearly divide up the content.

dokku deployment: https://happycows-nadavital-dev.dokku-07.cs.ucsb.edu

started issue #5 

## Screenshots (Optional)
<img width="1512" alt="Screenshot 2024-05-21 at 6 10 25 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-7/assets/92344347/ba2cc07d-298c-4696-9e03-a33de08c94fe">

## Feedback Request (Optional)
Please give suggestions on the following:
- What other refactoring would you like to see on the homepage?

## Future Possibilities (Optional)
<!--What do you think this project could become? Delete if not needed.-->
Some possible points could be:
- Change the items in the list to be cards which makes them more visually appealing, approachable, and could enable future functionality such as drag and drops or pop up menus from clicking on them
- limit the length of the name field of the common to be one line

## Validation (Optional)
1. Download this branch.
2. Run the project.
3. Go to the homepage
4. see that everything looks as it should

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 
