### PR TITLE
zc - fix bug for ability to navigate to unjoined commons

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,7 +16,6 @@ import AdminEditCommonsPage from "main/pages/AdminEditCommonsPage";
 import AdminListCommonsPage from "main/pages/AdminListCommonPage";
 import AdminReportsPage from "main/pages/AdminReportsPage";
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
-//import PlayPage from "main/pages/PlayPage";
 import NotFoundPage from "main/pages/NotFoundPage";
 import AdminViewPlayPage from "main/pages/AdminViewPlayPage";
 import ProtectedPlayPage from "main/pages/ProtectedPlayPage";

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,9 +16,10 @@ import AdminEditCommonsPage from "main/pages/AdminEditCommonsPage";
 import AdminListCommonsPage from "main/pages/AdminListCommonPage";
 import AdminReportsPage from "main/pages/AdminReportsPage";
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
-import PlayPage from "main/pages/PlayPage";
+//import PlayPage from "main/pages/PlayPage";
 import NotFoundPage from "main/pages/NotFoundPage";
 import AdminViewPlayPage from "main/pages/AdminViewPlayPage";
+import ProtectedPlayPage from "main/pages/ProtectedPlayPage";
 
 function App() {
     const { data: currentUser } = useCurrentUser();
@@ -58,7 +59,7 @@ function App() {
                 path="/leaderboard/:commonsId"
                 element={<LeaderboardPage />}
             />
-            <Route path="/play/:commonsId" element={<PlayPage />} />
+            <Route path="/play/:commonsId" element={<ProtectedPlayPage />} />
         </>
     ) : null;
 

--- a/frontend/src/main/pages/ProtectedPlayPage.js
+++ b/frontend/src/main/pages/ProtectedPlayPage.js
@@ -1,31 +1,21 @@
 import React from 'react';
 import { useParams, Navigate } from 'react-router-dom';
-import { useBackend } from 'main/utils/useBackend';
 import { useCurrentUser } from 'main/utils/currentUser';
 import PlayPage from 'main/pages/PlayPage';
 
 const ProtectedPlayPage = () => {
     const { commonsId } = useParams();
-    const { data: currentUser } = useCurrentUser();
+    const { data: currentUser} = useCurrentUser();
 
-    const { data: userCommons, error: userCommonsError } = useBackend(
-        [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`],
-        {
-            method: 'GET',
-            url: '/api/usercommons/forcurrentuser',
-            params: { commonsId },
-        }
+    const isUserInCommons = currentUser?.root?.user?.commons?.some(
+        (commons) => commons.id === parseInt(commonsId)
     );
 
-
-    if (!userCommons && !userCommonsError) {
+    if (!isUserInCommons) {
         return <Navigate to="/not-found" />;
-    } else {
-        return <PlayPage userCommons={userCommons} currentUser={currentUser} />;
     }
 
-
-    
+    return <PlayPage currentUser={currentUser} />;
 };
 
 export default ProtectedPlayPage;

--- a/frontend/src/main/pages/ProtectedPlayPage.js
+++ b/frontend/src/main/pages/ProtectedPlayPage.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useParams, Navigate } from 'react-router-dom';
+import { useBackend } from 'main/utils/useBackend';
+import { useCurrentUser } from 'main/utils/currentUser';
+import PlayPage from 'main/Pages/PlayPage';
+import NotFoundPage from 'main/Pages/NotFoundPage';
+
+const ProtectedPlayPage = () => {
+    const { commonsId } = useParams();
+    const { data: currentUser } = useCurrentUser();
+
+    // Stryker disable all
+    const { data: userCommons } = useBackend(
+        [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`],
+        {
+            method: "GET",
+            url: "/api/usercommons/forcurrentuser",
+            params: {
+                commonsId: commonsId,
+            },
+        }
+    );
+    // Stryker restore all
+
+    if (userCommons || commonsId) {
+        return <Navigate to="NotFoundPage" />;
+    }
+
+    return <PlayPage />;
+};
+
+export default ProtectedPlayPage;

--- a/frontend/src/main/pages/ProtectedPlayPage.js
+++ b/frontend/src/main/pages/ProtectedPlayPage.js
@@ -2,31 +2,30 @@ import React from 'react';
 import { useParams, Navigate } from 'react-router-dom';
 import { useBackend } from 'main/utils/useBackend';
 import { useCurrentUser } from 'main/utils/currentUser';
-import PlayPage from 'main/Pages/PlayPage';
-import NotFoundPage from 'main/Pages/NotFoundPage';
+import PlayPage from 'main/pages/PlayPage';
 
 const ProtectedPlayPage = () => {
     const { commonsId } = useParams();
     const { data: currentUser } = useCurrentUser();
 
-    // Stryker disable all
-    const { data: userCommons } = useBackend(
+    const { data: userCommons, error: userCommonsError } = useBackend(
         [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`],
         {
-            method: "GET",
-            url: "/api/usercommons/forcurrentuser",
-            params: {
-                commonsId: commonsId,
-            },
+            method: 'GET',
+            url: '/api/usercommons/forcurrentuser',
+            params: { commonsId },
         }
     );
-    // Stryker restore all
 
-    if (userCommons || commonsId) {
-        return <Navigate to="NotFoundPage" />;
+
+    if (!userCommons && !userCommonsError) {
+        return <Navigate to="/not-found" />;
+    } else {
+        return <PlayPage userCommons={userCommons} currentUser={currentUser} />;
     }
 
-    return <PlayPage />;
+
+    
 };
 
 export default ProtectedPlayPage;

--- a/frontend/src/tests/pages/ProtectedPlayPage.test.js
+++ b/frontend/src/tests/pages/ProtectedPlayPage.test.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import ProtectedPlayPage from 'main/pages/ProtectedPlayPage';
+import { useCurrentUser } from 'main/utils/currentUser';
+
+jest.mock('main/utils/currentUser');
+
+jest.mock('main/pages/PlayPage', () => {
+    return function MockedPlayPage() {
+        return <div>Mocked PlayPage</div>;
+    };
+});
+
+describe('ProtectedPlayPage', () => {
+    const renderComponent = (commonsId, currentUser) => {
+        useCurrentUser.mockReturnValue({ data: currentUser });
+        
+        return render(
+            <MemoryRouter initialEntries={[`/play/${commonsId}`]}>
+                <Routes>
+                    <Route path="/play/:commonsId" element={<ProtectedPlayPage />} />
+                    <Route path="/not-found" element={<div>Not Found Page</div>} />
+                </Routes>
+            </MemoryRouter>
+        );
+    };
+
+    test('renders PlayPage if user is in the commons', () => {
+        const currentUser = {
+            root: {
+                user: {
+                    commons: [{ id: 1 }, { id: 2 }]
+                }
+            }
+        };
+        const { getByText } = renderComponent(2, currentUser);
+        expect(getByText('Mocked PlayPage')).toBeInTheDocument();
+    });
+
+    test('navigates to Not Found page if user is not in the commons', () => {
+        const currentUser = {
+            root: {
+                user: {
+                    commons: [{ id: 1 }, { id: 3 }]
+                }
+            }
+        };
+        const { getByText } = renderComponent(2, currentUser);
+        expect(getByText('Not Found Page')).toBeInTheDocument();
+    });
+
+    test('navigates to Not Found page if currentUser is null', () => {
+        const { getByText } = renderComponent(2, null);
+        expect(getByText('Not Found Page')).toBeInTheDocument();
+    });
+
+    test('renders PlayPage if currentUser exists and commons is empty', () => {
+        const currentUser = {
+            root: {
+                user: {
+                    commons: []
+                }
+            }
+        };
+        const { getByText } = renderComponent(1, currentUser);
+        expect(getByText('Not Found Page')).toBeInTheDocument();
+    });
+
+    test('renders PlayPage if currentUser exists and commons is not an array', () => {
+        const currentUser = {
+            root: {
+                user: {
+                    commons: null
+                }
+            }
+        };
+        const { getByText } = renderComponent(1, currentUser);
+        expect(getByText('Not Found Page')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/tests/pages/ProtectedPlayPage.test.js
+++ b/frontend/src/tests/pages/ProtectedPlayPage.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import ProtectedPlayPage from 'main/pages/ProtectedPlayPage';
 import { useCurrentUser } from 'main/utils/currentUser';
@@ -34,8 +34,8 @@ describe('ProtectedPlayPage', () => {
                 }
             }
         };
-        const { getByText } = renderComponent(2, currentUser);
-        expect(getByText('Mocked PlayPage')).toBeInTheDocument();
+        renderComponent(2, currentUser);
+        expect(screen.getByText('Mocked PlayPage')).toBeInTheDocument();
     });
 
     test('navigates to Not Found page if user is not in the commons', () => {
@@ -46,28 +46,16 @@ describe('ProtectedPlayPage', () => {
                 }
             }
         };
-        const { getByText } = renderComponent(2, currentUser);
-        expect(getByText('Not Found Page')).toBeInTheDocument();
+        renderComponent(2, currentUser);
+        expect(screen.getByText('Not Found Page')).toBeInTheDocument();
     });
 
     test('navigates to Not Found page if currentUser is null', () => {
-        const { getByText } = renderComponent(2, null);
-        expect(getByText('Not Found Page')).toBeInTheDocument();
+        renderComponent(2, null);
+        expect(screen.getByText('Not Found Page')).toBeInTheDocument();
     });
 
-    test('renders PlayPage if currentUser exists and commons is empty', () => {
-        const currentUser = {
-            root: {
-                user: {
-                    commons: []
-                }
-            }
-        };
-        const { getByText } = renderComponent(1, currentUser);
-        expect(getByText('Not Found Page')).toBeInTheDocument();
-    });
-
-    test('renders PlayPage if currentUser exists and commons is not an array', () => {
+    test('navigates to Not Found page if currentUser exists and commons is not an array', () => {
         const currentUser = {
             root: {
                 user: {
@@ -75,21 +63,23 @@ describe('ProtectedPlayPage', () => {
                 }
             }
         };
-        const { getByText } = renderComponent(1, currentUser);
-        expect(getByText('Not Found Page')).toBeInTheDocument();
+        renderComponent(1, currentUser);
+        expect(screen.getByText('Not Found Page')).toBeInTheDocument();
     });
+
     test('navigates to Not Found page if user component does not exist', () => {
         const currentUser = {
             root: { 
             }
         };
-        const { getByText } = renderComponent(1, currentUser);
-        expect(getByText('Not Found Page')).toBeInTheDocument();
+        renderComponent(1, currentUser);
+        expect(screen.getByText('Not Found Page')).toBeInTheDocument();
     });
+
     test('navigates to Not Found page if root component does not exist', () => {
         const currentUser = {
         };
-        const { getByText } = renderComponent(1, currentUser);
-        expect(getByText('Not Found Page')).toBeInTheDocument();
+        renderComponent(1, currentUser);
+        expect(screen.getByText('Not Found Page')).toBeInTheDocument();
     });
 });

--- a/frontend/src/tests/pages/ProtectedPlayPage.test.js
+++ b/frontend/src/tests/pages/ProtectedPlayPage.test.js
@@ -78,4 +78,18 @@ describe('ProtectedPlayPage', () => {
         const { getByText } = renderComponent(1, currentUser);
         expect(getByText('Not Found Page')).toBeInTheDocument();
     });
+    test('navigates to Not Found page if user component does not exist', () => {
+        const currentUser = {
+            root: { 
+            }
+        };
+        const { getByText } = renderComponent(1, currentUser);
+        expect(getByText('Not Found Page')).toBeInTheDocument();
+    });
+    test('navigates to Not Found page if root component does not exist', () => {
+        const currentUser = {
+        };
+        const { getByText } = renderComponent(1, currentUser);
+        expect(getByText('Not Found Page')).toBeInTheDocument();
+    });
 });

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -335,8 +335,8 @@ public class CommonsController extends ApiController {
 
     @Operation(summary="Delete a user from a commons")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @GetMapping("/{commonsId}/users/{userId}")
-    public Object accessCommon(@PathVariable("commonsId") Long commonsId,
+    @DeleteMapping("/{commonsId}/users/{userId}")
+    public Object deleteUserFromCommon(@PathVariable("commonsId") Long commonsId,
                                        @PathVariable("userId") Long userId) throws Exception {
 
         UserCommons userCommons = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -335,8 +335,8 @@ public class CommonsController extends ApiController {
 
     @Operation(summary="Delete a user from a commons")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @DeleteMapping("/{commonsId}/users/{userId}")
-    public Object deleteUserFromCommon(@PathVariable("commonsId") Long commonsId,
+    @GetMapping("/{commonsId}/users/{userId}")
+    public Object accessCommon(@PathVariable("commonsId") Long commonsId,
                                        @PathVariable("userId") Long userId) throws Exception {
 
         UserCommons userCommons = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)


### PR DESCRIPTION
## Overview
In this PR, I fixed the bug that a user can navigate to an unjoined common (by directly modifying the common id in url) by adding a redirect page (changed App.js user role redirection and added a new access page) (so that the user is navigated to the existed 404 Not Found page)

## Screenshots
![WeChatef81dd413d8f4a547f1bc24fbd2f917f](https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-7/assets/17016528/5fa52ee3-7993-410a-9a1d-4db214314543)
when accessing common 2 which I did not join
![WeChat85001fbd962a97f9834b085e2aad1359](https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-7/assets/17016528/94635e3b-8d80-4cb5-90ef-a92daf481f0b)
![WeChat307333f019a09c85c7e745eb9d511b39](https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-7/assets/17016528/b5568da0-5008-47d9-b05a-5655ed2a7ba6)

## Validation
1. Go to https://happycows-chendashi-dev.dokku-07.cs.ucsb.edu/
2. There should be two commons already exist
3. visit common1, and change url https://happycows-chendashi-dev.dokku-07.cs.ucsb.edu/play/2
4. you will be redirected to the 404 Not Found Page

## Tests
-  Frontend Test coverage (`npm run coverage`) 100%
-  Frontend Mutation tests (`npx stryker run`) 100% 

## Linked Issues
Closes #6 
