### PR TITLE
zc - Latest Commit tracker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apk add curl
 RUN apk add bash
 RUN apk add maven
 RUN apk add --no-cache libstdc++
+RUN apk add git
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 ENV NVM_DIR=/root/.nvm
 RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
@@ -15,13 +16,11 @@ RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 
-RUN node --version
-RUN npm --version
+# This approach (copying entire directory including git info) 
+# relies on the dokku setting:
+#   dokku git:set appname keep-git-dir true
 
-COPY frontend /home/app/frontend
-COPY src /home/app/src
-COPY lombok.config /home/app
-COPY pom.xml /home/app
+COPY . /home/app
 
 ENV PRODUCTION=true
 RUN mvn -B -DskipTests -Pproduction -f /home/app/pom.xml clean package

--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,25 @@
                     <timestampedReports>false</timestampedReports>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>8.0.2</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                    <commitIdGenerationMode>full</commitIdGenerationMode>
+                </configuration>
+            </plugin>
 
 
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -292,6 +292,11 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <includeOnlyProperties>
+                            <includeOnlyProperty>^git.build.(time|version)$</includeOnlyProperty>
+                            <includeOnlyProperty>^git.commit.id.(abbrev|full)$</includeOnlyProperty>
+                            <includeOnlyProperty>^git.commit.message.short$</includeOnlyProperty>
+                    </includeOnlyProperties>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
                     <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
                     <commitIdGenerationMode>full</commitIdGenerationMode>

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/SystemInfo.java
@@ -13,6 +13,11 @@ import lombok.AccessLevel;
 public class SystemInfo {
   private Boolean springH2ConsoleEnabled;
   private Boolean showSwaggerUILink;
-  private String sourceRepo;
+  private String startQtrYYYYQ;
+  private String endQtrYYYYQ;
+  private String sourceRepo; // user configured URL of the source repository for footer
+  private String commitMessage;
+  private String commitId;
+  private String githubUrl; // URL to the commit in the source repository
   private String oauthLogin;
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/SystemInfo.java
@@ -19,5 +19,4 @@ public class SystemInfo {
   private String commitMessage;
   private String commitId;
   private String githubUrl; // URL to the commit in the source repository
-  private String oauthLogin;
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImpl.java
@@ -22,21 +22,42 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
+  @Value("${app.startQtrYYYYQ:20242}")
+  private String startQtrYYYYQ;
+
+  @Value("${app.endQtrYYYYQ:20243}")
+  private String endQtrYYYYQ;
+
   @Value("${app.sourceRepo}")
-  private String sourceRepo = "https://github.com/ucsb-cs156/proj-happycows";
+  private String sourceRepo = "https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-7";
+
+  @Value("${git.commit.message.short:unknown}")
+  private String commitMessage;
+
+  @Value("${git.commit.id.abbrev:unknown}")
+  private String commitId;
 
   @Value("${app.oauth.login:/oauth2/authorization/google}")
   private String oauthLogin;
 
-  public SystemInfo getSystemInfo() {
-    SystemInfo si = SystemInfo.builder()
-    .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
-    .showSwaggerUILink(this.showSwaggerUILink)
-    .sourceRepo(this.sourceRepo)
-    .oauthLogin(this.oauthLogin)
-    .build();
-  log.info("getSystemInfo returns {}",si);
-  return si;
+  public static String githubUrl(String repo, String commit) {
+    return commit != null && repo != null ? repo + "/commit/" + commit : null;
   }
 
+  public SystemInfo getSystemInfo() {
+    SystemInfo si =
+        SystemInfo.builder()
+            .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
+            .showSwaggerUILink(this.showSwaggerUILink)
+            .startQtrYYYYQ(this.startQtrYYYYQ)
+            .endQtrYYYYQ(this.endQtrYYYYQ)
+            .sourceRepo(this.sourceRepo)
+            .commitMessage(this.commitMessage)
+            .commitId(this.commitId)
+            .githubUrl(githubUrl(this.sourceRepo, this.commitId))
+            .oauthLogin(this.oauthLogin)
+            .build();
+    log.info("getSystemInfo returns {}", si);
+    return si;
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImpl.java
@@ -42,9 +42,6 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${git.commit.id.abbrev:unknown}")
   private String commitId;
 
-  @Value("${app.oauth.login:/oauth2/authorization/google}")
-  private String oauthLogin;
-
   public static String githubUrl(String repo, String commit) {
     return commit != null && repo != null ? repo + "/commit/" + commit : null;
   }
@@ -60,7 +57,6 @@ public class SystemInfoServiceImpl extends SystemInfoService {
             .commitMessage(this.commitMessage)
             .commitId(this.commitId)
             .githubUrl(githubUrl(this.sourceRepo, this.commitId))
-            .oauthLogin(this.oauthLogin)
             .build();
     log.info("getSystemInfo returns {}", si);
     return si;

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImpl.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Service;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySources;
 
 import edu.ucsb.cs156.happiercows.models.SystemInfo;
 
@@ -14,6 +16,9 @@ import edu.ucsb.cs156.happiercows.models.SystemInfo;
 @Slf4j
 @Service("systemInfo")
 @ConfigurationProperties
+@PropertySources(
+        @PropertySource("classpath:git.properties")
+)
 public class SystemInfoServiceImpl extends SystemInfoService {
   
   @Value("${spring.h2.console.enabled:false}")

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/SystemInfoControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/SystemInfoControllerTests.java
@@ -38,7 +38,6 @@ public class SystemInfoControllerTests extends ControllerTestCase {
         .showSwaggerUILink(true)
         .springH2ConsoleEnabled(true)
         .sourceRepo("https://github.com/ucsb-cs156/proj-happycows")
-        .oauthLogin("/oauth2/authorization/google")
         .build();
     when(mockSystemInfoService.getSystemInfo()).thenReturn(systemInfo);
     String expectedJson = mapper.writeValueAsString(systemInfo);
@@ -65,7 +64,6 @@ public class SystemInfoControllerTests extends ControllerTestCase {
         .showSwaggerUILink(true)
         .springH2ConsoleEnabled(true)
         .sourceRepo("https://github.com/ucsb-cs156/proj-happycows")
-        .oauthLogin("/oauth2/authorization/google")
         .build();
     when(mockSystemInfoService.getSystemInfo()).thenReturn(systemInfo);
     String expectedJson = mapper.writeValueAsString(systemInfo);
@@ -92,7 +90,6 @@ public class SystemInfoControllerTests extends ControllerTestCase {
         .showSwaggerUILink(true)
         .springH2ConsoleEnabled(true)
         .sourceRepo("https://github.com/ucsb-cs156/proj-happycows")
-        .oauthLogin("/oauth2/authorization/google")
         .build();
     when(mockSystemInfoService.getSystemInfo()).thenReturn(systemInfo);
     String expectedJson = mapper.writeValueAsString(systemInfo);

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImplTests.java
@@ -1,7 +1,8 @@
 package edu.ucsb.cs156.happiercows.services;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,7 +30,20 @@ class SystemInfoServiceImplTests  {
     SystemInfo si = systemInfoService.getSystemInfo();
     assertTrue(si.getSpringH2ConsoleEnabled());
     assertTrue(si.getShowSwaggerUILink());
-    assertEquals("https://github.com/ucsb-cs156/proj-happycows", si.getSourceRepo());
+    assertTrue(si.getGithubUrl().startsWith(si.getSourceRepo()));
+    assertTrue(si.getGithubUrl().endsWith(si.getCommitId()));
+    assertTrue(si.getGithubUrl().contains("/commit/"));
+  }
+
+  @Test
+  void test_githubUrl() {
+    assertEquals(
+        SystemInfoServiceImpl.githubUrl(
+            "https://github.com/ucsb-cs156/proj-courses", "abcdef12345"),
+        "https://github.com/ucsb-cs156/proj-courses/commit/abcdef12345");
+    assertNull(SystemInfoServiceImpl.githubUrl(null, null));
+    assertNull(SystemInfoServiceImpl.githubUrl("x", null));
+    assertNull(SystemInfoServiceImpl.githubUrl(null, "x"));
   }
 
 }


### PR DESCRIPTION
## Overview
In this PR, I modified docker file, pom.xml, and several systemInfo related file so that the commit info can be fetched through maven plugin and displayed through /api/systemInfo.


## Screenshots
![WeChat0991d6fe303b38ddd2ad59fefe9ce12b](https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-7/assets/17016528/12f0c21b-dc98-42ea-b400-e2338028b573)


## Validation
https://happycows-chendashi-dev.dokku-07.cs.ucsb.edu/api/systemInfo
\
To ensure the tracker will work on dokku, the following two lines needs to be executed before ps:rebuild command. (substitude x with proper name)\
```dokku git:set happycows-xx-dev keep-git-dir true```\
```dokku config:set happycows-xx-dev  SOURCE_REPO=https://ucsb-cs156-s24/proj-happycows-s24-xpm-x```

## Tests
- Backend Unit tests (`mvn test`) pass
- Frontend Test coverage (`npm run coverage`) 100%
- Frontend Mutation tests (`npx stryker run`) 100% 

## Linked Issues
<!--Issues related to the PR-->
Closes #3 
