### PR TITLE
zc - add Swagger option on navbar

### DIFF
--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -5,7 +5,7 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
 spring.h2.console.enabled=true
-app.showSwaggerUILink=true
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:true}}
 app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-happycows}}
 
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/src/main/resources/application-integration.properties
+++ b/src/main/resources/application-integration.properties
@@ -5,7 +5,7 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
 spring.h2.console.enabled=true
-app.showSwaggerUILink=true
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:true}}
 app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-happycows}}
 
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -3,3 +3,5 @@ spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect
+
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}

--- a/src/main/resources/application-wiremock.properties
+++ b/src/main/resources/application-wiremock.properties
@@ -5,7 +5,7 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
 spring.h2.console.enabled=true
-app.showSwaggerUILink=true
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:true}}
 app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-happycows}}
 
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## Overview
In this PR, the variable SHOW_SWAGGER_UI_LINK are to set env variables (so that it will read values from dokku env variables) for all application property files under src/main/resources/db, so that a swagger link option is displayed in the navigation bar if the env variable pre-set to true for that dokku build.

## Screenshots
a swagger nav bar will show if the env variable is set to true in dokku \
run below command before ps:rebuild. substitute xxx with your github id or proper dokku app name \
```dokku config:set --no-restart happycows-xxx-dev SHOW_SWAGGER_UI_LINK=true```
![WeChat4c715794642133bf9b907dc4dc9c784e](https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-7/assets/17016528/074fd5ba-4823-4e7d-b212-0db7cf37abe0)


## Validation
In https://happycows-chendashi-dev.dokku-07.cs.ucsb.edu/api/systemInfo, ```"showSwaggerUILink":true```.
In https://happycows-chendashi-dev.dokku-07.cs.ucsb.edu, a swagger option will appear in the upper left corner.

## Tests
- Backend Unit tests (`mvn test`) pass
- Backend Test coverage (`mvn test jacoco:report`) 100%
- Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- Frontend Unit tests (`npm test`) pass
- Frontend Test coverage (`npm run coverage`) 100%
- Frontend Mutation tests (`npx stryker run`) 100% 

## Linked Issues
Closes #11 
