### PR TITLE
mz - adding suspended field to user

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
@@ -26,6 +26,8 @@ public class User {
     private String locale;
     private String hostedDomain;
     private boolean admin;
+    @Builder.Default
+    private boolean suspended = false;
 
   @Builder.Default
   private Instant lastOnline = Instant.now();


### PR DESCRIPTION
## Overview
In this PR, I addressed issue B1 found [here](https://github.com/ucsb-cs156/proj-happycows/issues/124), adding a suspend field to the User class.

## Future Possibilities (Optional)
- This is the beginning/part of allowing admins to suspend users from the commons, see above linked issue for more detail.

## Tests
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [ ] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
Doesn't close but related to #8
