### PR TITLE
na - Fixed Announcement POST Bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1"
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
@@ -51,7 +51,7 @@ public class AnnouncementsController extends ApiController{
         @Parameter(description = "The id of the common") @RequestParam Long commonsId,
         @Parameter(description = "The datetime at which the announcement will be shown (defaults to current time)") @RequestParam(required = false) Date startDate,
         @Parameter(description = "The datetime at which the announcement will stop being shown (optional)") @RequestParam(required = false) Date endDate,
-        @Parameter(description = "The announcement to be sent out") @RequestParam String announcementText) {
+        @Parameter(description = "The announcement to be sent out") @RequestBody String announcementText) {
 
         User user = getCurrentUser().getUser();
         Long userId = user.getId();


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
Fixed the bug where the announcement post endpoint uses the URI params instead of body params, now there is a large request body field on swagger.

## Screenshots (Optional)
<img width="1512" alt="Screenshot 2024-05-24 at 5 10 32 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-7/assets/92344347/8c500de7-9626-4fe5-836a-fe7824537f79">


## Tests
<!--Add any additional tests or required tests-->
- [ ] Backend Unit tests (`mvn test`) pass
- [ ] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [ ] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #31 
