### PR TITLE
na - updated pom.xml for partial pitest runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,16 @@ In order to run the end-to-end tests 'not headless' use the following instead of
 ```
 INTEGRATION=true HEADLESS=false mvn failsafe:integration-test
 ```
+
+## Partial pitest runs
+
+This repo has support for partial pitest runs
+
+For example, to run pitest on just one class, use:
+```
+mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.happiercows.controllers.CommonsController
+```
+To run pitest on just one package, use:
+```
+mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.happiercows.controllers.\*
+```

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <description>A Simulation Game of the Tragedy of the Commons.</description>
     <properties>
         <java.version>17</java.version>
+        <targetClasses>${targetClasses:edu.ucsb.cs156.*}</targetClasses>
     </properties>
     <dependencies>
         <dependency>
@@ -237,7 +238,7 @@
                     </historyOutputFile>
                     <verbose>true</verbose>
                     <targetClasses>
-                        <param>edu.ucsb.cs156.*</param>
+                        <param>${targetClasses}</param>
                     </targetClasses>
                     <targetTests>
                         <param>edu.ucsb.cs156.*</param>


### PR DESCRIPTION
## Overview
updated pom.xml to support partial pietist runs according to the sample PR that Professor Conrad posted in the slack.

## Tests
<!--Add any additional tests or required tests-->
- [ ] Backend Unit tests (`mvn test`) pass
- [ ] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [ ] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
Closes #33 
