### PR TITLE
na - further UI refactoring

### DIFF
--- a/frontend/src/main/components/Commons/CommonsCard.js
+++ b/frontend/src/main/components/Commons/CommonsCard.js
@@ -40,6 +40,7 @@ const CommonsCard = ({ buttonText, buttonLink, commons, color }) => {
                                 data-testid={`${testIdPrefix}-button-${buttonText}-${commons.id}`}
                                 size="sm"
                                 className="mx-4"
+                                style={{ backgroundColor: 'rgba(255, 255, 255, 0.3)', outline: 'none', border: 'none', fontWeight: 'bold', color: 'rgba(0, 0, 0, 0.7)'}}
                                 onClick={() => {
                                     if (buttonText === "Join" && isFutureDate(commons.startingDate)) {
                                         // Stryker disable next-line all: unable to read alert text in tests

--- a/frontend/src/main/components/Commons/CommonsCard.js
+++ b/frontend/src/main/components/Commons/CommonsCard.js
@@ -24,16 +24,15 @@ function isFutureDate(startingDate) {
     }
 }
 
-const CommonsCard = ({ buttonText, buttonLink, commons }) => {
+const CommonsCard = ({ buttonText, buttonLink, commons, color }) => {
     const testIdPrefix = "commonsCard";
     return (
         <Card.Body style={
             // Stryker disable next-line all : don't mutation test CSS 
-            { fontSize: "20px", boxShadow: "5px 5px 5px lightgrey", borderRadius: "10px", margin: "10px", background: "rgba(255, 255, 255, 0.7)", backdropFilter: "blur(10px)", WebkitBackdropFilter: "blur(10px)" }
+            { fontSize: "20px", boxShadow: "5px 5px 5px lightgrey", borderRadius: "10px", margin: "10px", backgroundColor: color, backdropFilter: "blur(10px)", WebkitBackdropFilter: "blur(10px)" }
         }>
             <Container>
                 <Row>
-                    <Col sx={4} data-testid={`${testIdPrefix}-id-${commons.id}`}>{commons.id}</Col>
                     <Col sx={4} data-testid={`${testIdPrefix}-name-${commons.id}`}>{commons.name}</Col>
                     {buttonText != null &&
                         <Col sm={4}>

--- a/frontend/src/main/components/Commons/CommonsCard.js
+++ b/frontend/src/main/components/Commons/CommonsCard.js
@@ -40,6 +40,7 @@ const CommonsCard = ({ buttonText, buttonLink, commons, color }) => {
                                 data-testid={`${testIdPrefix}-button-${buttonText}-${commons.id}`}
                                 size="sm"
                                 className="mx-4"
+                                // Stryker disable next-line all : don't mutation test CSS 
                                 style={{ backgroundColor: 'rgba(255, 255, 255, 0.3)', outline: 'none', border: 'none', fontWeight: 'bold', color: 'rgba(0, 0, 0, 0.7)'}}
                                 onClick={() => {
                                     if (buttonText === "Join" && isFutureDate(commons.startingDate)) {

--- a/frontend/src/main/components/Commons/CommonsCard.js
+++ b/frontend/src/main/components/Commons/CommonsCard.js
@@ -29,7 +29,7 @@ const CommonsCard = ({ buttonText, buttonLink, commons }) => {
     return (
         <Card.Body style={
             // Stryker disable next-line all : don't mutation test CSS 
-            { fontSize: "20px", borderTop: "1px solid lightgrey" }
+            { fontSize: "20px", boxShadow: "5px 5px 5px lightgrey", borderRadius: "10px", margin: "10px", background: "rgba(255, 255, 255, 0.7)", backdropFilter: "blur(10px)", WebkitBackdropFilter: "blur(10px)" }
         }>
             <Container>
                 <Row>

--- a/frontend/src/main/components/Commons/CommonsList.js
+++ b/frontend/src/main/components/Commons/CommonsList.js
@@ -3,6 +3,7 @@ import CommonsCard from "./CommonsCard";
 import { Card, Container, Row, Col } from "react-bootstrap";
 
 const CommonsList = (props) => {
+    // Stryker disable all: don't test removing colors
     const cardColors = [
         "rgba(255, 215, 0, 0.7)",     // Gold
         "rgba(255, 160, 122, 0.7)",   // Light Salmon
@@ -39,6 +40,7 @@ const CommonsList = (props) => {
         "rgba(47, 79, 79, 0.7)",      // Dark Slate Gray
         "rgba(139, 0, 139, 0.7)"      // Dark Magenta
       ];
+      // Stryker restore all
       
     const defaultMessage = props.title?.includes("Join") ? "join" : "visit";
 

--- a/frontend/src/main/components/Commons/CommonsList.js
+++ b/frontend/src/main/components/Commons/CommonsList.js
@@ -50,7 +50,7 @@ const CommonsList = (props) => {
                 { background: 'rgba(255, 255, 255, 0.7)', 
                     borderRadius: '10px', 
                     padding: '10px', 
-                    boxShadow: '5px 5px 5px lightgrey',
+                    boxShadow: '5px 5px 10px 5px lightgrey',
                     backdropFilter: 'blur(10px)', 
                     WebkitBackdropFilter: 'blur(10px)'}
                 // Stryker restore all

--- a/frontend/src/main/components/Commons/CommonsList.js
+++ b/frontend/src/main/components/Commons/CommonsList.js
@@ -83,7 +83,7 @@ const CommonsList = (props) => {
                 </Card.Subtitle>
                 {
                     props.commonList.map(
-                        (c) => (<CommonsCard key={c.id} commons={c} buttonText={props.buttonText} buttonLink={props.buttonLink} color={cardColors[c.id]} />)
+                        (c) => (<CommonsCard key={c.id} commons={c} buttonText={props.buttonText} buttonLink={props.buttonLink} color={cardColors[c.id % cardColors.length]} />)
                     )
                 }
             </React.Fragment> 

--- a/frontend/src/main/components/Commons/CommonsList.js
+++ b/frontend/src/main/components/Commons/CommonsList.js
@@ -3,6 +3,43 @@ import CommonsCard from "./CommonsCard";
 import { Card, Container, Row, Col } from "react-bootstrap";
 
 const CommonsList = (props) => {
+    const cardColors = [
+        "rgba(255, 215, 0, 0.7)",     // Gold
+        "rgba(255, 160, 122, 0.7)",   // Light Salmon
+        "rgba(32, 178, 170, 0.7)",    // Light Sea Green
+        "rgba(135, 206, 250, 0.7)",   // Light Sky Blue
+        "rgba(255, 182, 193, 0.7)",   // Light Pink
+        "rgba(152, 251, 152, 0.7)",   // Pale Green
+        "rgba(255, 99, 71, 0.7)",     // Tomato
+        "rgba(255, 165, 0, 0.7)",     // Orange
+        "rgba(0, 255, 127, 0.7)",     // Spring Green
+        "rgba(255, 105, 180, 0.7)",   // Hot Pink
+        "rgba(0, 255, 255, 0.7)",     // Cyan / Aqua
+        "rgba(255, 218, 185, 0.7)",   // Peach Puff
+        "rgba(123, 104, 238, 0.7)",   // Medium Slate Blue
+        "rgba(240, 230, 140, 0.7)",   // Khaki
+        "rgba(216, 191, 216, 0.7)",   // Thistle
+        "rgba(255, 192, 203, 0.7)",   // Pink
+        "rgba(221, 160, 221, 0.7)",   // Plum
+        "rgba(176, 224, 230, 0.7)",   // Powder Blue
+        "rgba(255, 127, 80, 0.7)",    // Coral
+        "rgba(70, 130, 180, 0.7)",    // Steel Blue
+        "rgba(218, 165, 32, 0.7)",    // Goldenrod
+        "rgba(128, 128, 128, 0.7)",   // Gray
+        "rgba(0, 128, 128, 0.7)",     // Teal
+        "rgba(139, 69, 19, 0.7)",     // Saddle Brown
+        "rgba(46, 139, 87, 0.7)",     // Sea Green
+        "rgba(128, 0, 0, 0.7)",       // Maroon
+        "rgba(138, 43, 226, 0.7)",    // Blue Violet
+        "rgba(75, 0, 130, 0.7)",      // Indigo
+        "rgba(85, 107, 47, 0.7)",     // Dark Olive Green
+        "rgba(153, 50, 204, 0.7)",    // Dark Orchid
+        "rgba(139, 0, 0, 0.7)",       // Dark Red
+        "rgba(72, 61, 139, 0.7)",     // Dark Slate Blue
+        "rgba(47, 79, 79, 0.7)",      // Dark Slate Gray
+        "rgba(139, 0, 139, 0.7)"      // Dark Magenta
+      ];
+      
     const defaultMessage = props.title?.includes("Join") ? "join" : "visit";
 
     return (
@@ -13,6 +50,7 @@ const CommonsList = (props) => {
                 { background: 'rgba(255, 255, 255, 0.7)', 
                     borderRadius: '10px', 
                     padding: '10px', 
+                    boxShadow: '5px 5px 5px lightgrey',
                     backdropFilter: 'blur(10px)', 
                     WebkitBackdropFilter: 'blur(10px)'}
                 // Stryker restore all
@@ -38,7 +76,6 @@ const CommonsList = (props) => {
                 <Card.Subtitle>
                     <Container>
                         <Row>
-                            <Col data-testid="commonsList-subtitle-id" sx={4}>ID#</Col>
                             <Col data-testid="commonsList-subtitle-name" sx={4}>Common's Name</Col>
                             <Col sm={4}></Col>
                         </Row>
@@ -46,7 +83,7 @@ const CommonsList = (props) => {
                 </Card.Subtitle>
                 {
                     props.commonList.map(
-                        (c) => (<CommonsCard key={c.id} commons={c} buttonText={props.buttonText} buttonLink={props.buttonLink} />)
+                        (c) => (<CommonsCard key={c.id} commons={c} buttonText={props.buttonText} buttonLink={props.buttonLink} color={cardColors[c.id]} />)
                     )
                 }
             </React.Fragment> 

--- a/frontend/src/main/pages/HomePage.css
+++ b/frontend/src/main/pages/HomePage.css
@@ -14,6 +14,7 @@
     -webkit-backdrop-filter: blur(10px); 
     display: inline-block;
     margin-bottom: 0px;
+    box-shadow: 5px 5px 10px 5px lightgrey;
 }
 
 .subtitle{

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -11,6 +11,28 @@ import getBackgroundImage from "main/components/Utils/HomePageBackground";
 
 import "./HomePage.css"
 
+export function getRandomGreeting() {
+  const greetings = [
+    "Howdy Farmer",
+    "Hello Farmer",
+    "Hi Farmer",
+    "Greetings Farmer",
+    "Welcome Farmer",
+    "Hey there Farmer",
+    "Good to see you Farmer",
+    "Salutations Farmer",
+    "What's up Farmer",
+    "Ahoy Farmer",
+    "Good day Farmer",
+    "Pleased to see you Farmer",
+    "Welcome back Farmer",
+    "Hello there Farmer",
+  ];
+
+  const randomIndex = Math.floor(Math.random() * greetings.length);
+  return greetings[randomIndex];
+}
+
 export default function HomePage({hour=null}) {
   // Stryker disable next-line all: it is acceptable to exclude useState calls from mutation testing
   const [commonsJoined, setCommonsJoined] = useState([]);
@@ -62,28 +84,6 @@ export default function HomePage({hour=null}) {
 
   //create a list of commons that the user hasn't joined for use in the "Join a New Commons" list.
   const commonsNotJoinedList = commonsNotJoined(commons, commonsJoined);
-
-  const greetings = [
-    "Howdy Farmer",
-    "Hello Farmer",
-    "Hi Farmer",
-    "Greetings Farmer",
-    "Welcome Farmer",
-    "Hey there Farmer",
-    "Good to see you Farmer",
-    "Salutations Farmer",
-    "What's up Farmer",
-    "Ahoy Farmer",
-    "Good day Farmer",
-    "Pleased to see you Farmer",
-    "Welcome back Farmer",
-    "Hello there Farmer",
-  ];
-
-  function getRandomGreeting() {
-    const randomIndex = Math.floor(Math.random() * greetings.length);
-    return greetings[randomIndex];
-  }
   
   return (
     <div data-testid={"HomePage-main-div"} style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -62,12 +62,34 @@ export default function HomePage({hour=null}) {
 
   //create a list of commons that the user hasn't joined for use in the "Join a New Commons" list.
   const commonsNotJoinedList = commonsNotJoined(commons, commonsJoined);
+
+  const greetings = [
+    "Howdy Farmer",
+    "Hello Farmer",
+    "Hi Farmer",
+    "Greetings Farmer",
+    "Welcome Farmer",
+    "Hey there Farmer",
+    "Good to see you Farmer",
+    "Salutations Farmer",
+    "What's up Farmer",
+    "Ahoy Farmer",
+    "Good day Farmer",
+    "Pleased to see you Farmer",
+    "Welcome back Farmer",
+    "Hello there Farmer",
+  ];
+
+  function getRandomGreeting() {
+    const randomIndex = Math.floor(Math.random() * greetings.length);
+    return greetings[randomIndex];
+  }
   
   return (
     <div data-testid={"HomePage-main-div"} style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
       <BasicLayout>
         <div data-testid= {"HomePage-intro-card"} className="title-box">
-          <h1 data-testid="homePage-title" className="new-title" >Howdy Farmer {firstName}!</h1>
+          <h1 data-testid="homePage-title" className="new-title" >{getRandomGreeting()} {firstName}!</h1>
         </div>
         <Container>
           <Row>

--- a/frontend/src/tests/components/Commons/CommonsCard.test.js
+++ b/frontend/src/tests/components/Commons/CommonsCard.test.js
@@ -23,11 +23,6 @@ describe("CommonsCard tests", () => {
         expect(name).toBeInTheDocument();
         expect(typeof (name.textContent)).toBe('string');
         expect(name.textContent).toEqual('Seths Common');
-
-        const id = screen.getByTestId("commonsCard-id-5");
-        expect(id).toBeInTheDocument();
-        expect(typeof (id.textContent)).toBe('string');
-        expect(id.textContent).toEqual('5');
     });
 
     test("renders no button when button text is null", () => {
@@ -41,11 +36,6 @@ describe("CommonsCard tests", () => {
         expect(name).toBeInTheDocument();
         expect(typeof (name.textContent)).toBe('string');
         expect(name.textContent).toEqual('Seths Common');
-
-        const id = screen.getByTestId("commonsCard-id-5");
-        expect(id).toBeInTheDocument();
-        expect(typeof (id.textContent)).toBe('string');
-        expect(id.textContent).toEqual('5');
     });
 
     test("cannot join commons with future start date - future year", async () => {

--- a/frontend/src/tests/components/Commons/CommonsList.test.js
+++ b/frontend/src/tests/components/Commons/CommonsList.test.js
@@ -18,11 +18,6 @@ describe("CommonsList tests", () => {
         expect(typeof(subtitle_name.textContent)).toBe('string');
         expect(subtitle_name.textContent).toEqual("Common's Name");
 
-        const subtitle_id = screen.getByTestId("commonsList-subtitle-id");
-        expect(subtitle_id).toBeInTheDocument();
-        expect(typeof(subtitle_id.textContent)).toBe('string');
-        expect(subtitle_id.textContent).toEqual('ID#');
-
         const buttons = screen.getAllByTestId(/commonsCard-button/);
         buttons.forEach((b) => {
             expect(b).toBeInTheDocument();
@@ -36,15 +31,6 @@ describe("CommonsList tests", () => {
             expect(n).toBeInTheDocument();
             expect(typeof(n.textContent)).toBe('string');
             expect(n.textContent).toEqual(commonsFixtures.threeCommons[i].name);
-            i++;
-        })
-
-        i = 0;
-        const ids = screen.getAllByTestId(/commonsCard-id/);
-        ids.forEach((id) => {
-            expect(id).toBeInTheDocument();
-            expect(typeof(id.textContent)).toBe('string');
-            expect(id.textContent).toEqual(commonsFixtures.threeCommons[i].id.toString());
             i++;
         })
     });
@@ -64,11 +50,6 @@ describe("CommonsList tests", () => {
         expect(typeof(subtitle_name.textContent)).toBe('string');
         expect(subtitle_name.textContent).toEqual("Common's Name");
 
-        const subtitle_id = screen.getByTestId("commonsList-subtitle-id");
-        expect(subtitle_id).toBeInTheDocument();
-        expect(typeof(subtitle_id.textContent)).toBe('string');
-        expect(subtitle_id.textContent).toEqual('ID#');
-
         expect(() => screen.getAllByTestId(/commonsCard-button/)).toThrow('Unable to find an element');
 
         let i = 0;
@@ -77,15 +58,6 @@ describe("CommonsList tests", () => {
             expect(n).toBeInTheDocument();
             expect(typeof(n.textContent)).toBe('string');
             expect(n.textContent).toEqual(commonsFixtures.threeCommons[i].name);
-            i++;
-        })
-
-        i = 0;
-        const ids = screen.getAllByTestId(/commonsCard-id/);
-        ids.forEach((id) => {
-            expect(id).toBeInTheDocument();
-            expect(typeof(id.textContent)).toBe('string');
-            expect(id.textContent).toEqual(commonsFixtures.threeCommons[i].id.toString());
             i++;
         })
     });

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -4,7 +4,7 @@ import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
-import HomePage from "main/pages/HomePage";
+import HomePage, {getRandomGreeting} from "main/pages/HomePage";
 import commonsFixtures from "fixtures/commonsFixtures";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
@@ -52,6 +52,59 @@ describe("HomePage tests", () => {
         await waitFor(() => {
             expect(title.textContent).toContain('Farmer Phillip!');
         });
+    });
+
+    test("getRandomGreeting returns a valid greeting", () => {
+        const greetings = [
+            "Howdy Farmer",
+            "Hello Farmer",
+            "Hi Farmer",
+            "Greetings Farmer",
+            "Welcome Farmer",
+            "Hey there Farmer",
+            "Good to see you Farmer",
+            "Salutations Farmer",
+            "What's up Farmer",
+            "Ahoy Farmer",
+            "Good day Farmer",
+            "Pleased to see you Farmer",
+            "Welcome back Farmer",
+            "Hello there Farmer",
+        ];
+    
+        for (let i = 0; i < 100; i++) {
+            const greeting = getRandomGreeting();
+            expect(greetings).toContain(greeting);
+        }
+    });
+
+    test("getRandomGreeting uses correct randomIndex", () => {
+        const greetings = [
+            "Howdy Farmer",
+            "Hello Farmer",
+            "Hi Farmer",
+            "Greetings Farmer",
+            "Welcome Farmer",
+            "Hey there Farmer",
+            "Good to see you Farmer",
+            "Salutations Farmer",
+            "What's up Farmer",
+            "Ahoy Farmer",
+            "Good day Farmer",
+            "Pleased to see you Farmer",
+            "Welcome back Farmer",
+            "Hello there Farmer",
+        ];
+
+        const mockMath = Object.create(global.Math);
+        mockMath.random = () => 0.5; // This will return a fixed value
+        global.Math = mockMath;
+
+        const greeting = getRandomGreeting();
+        const expectedIndex = Math.floor(0.5 * greetings.length);
+        expect(greeting).toBe(greetings[expectedIndex]);
+
+        global.Math = mockMath; // Restore original Math.random
     });
 
     test("renders with default for commons when api times out", () => {

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -50,7 +50,7 @@ describe("HomePage tests", () => {
         expect(typeof (title.textContent)).toBe('string');
         
         await waitFor(() => {
-            expect(title.textContent).toEqual('Howdy Farmer Phillip!');
+            expect(title.textContent).toContain('Farmer Phillip!');
         });
     });
 
@@ -71,7 +71,7 @@ describe("HomePage tests", () => {
         const title = screen.getByTestId("homePage-title");
         expect(title).toBeInTheDocument();
         expect(typeof (title.textContent)).toBe('string');
-        expect(title.textContent).toEqual('Howdy Farmer Phillip!');
+        expect(title.textContent).toContain('Farmer Phillip!');
     });
 
     test("expected CSS properties", () => {
@@ -103,7 +103,7 @@ describe("HomePage tests", () => {
         const title = screen.getByTestId("homePage-title");
         expect(title).toBeInTheDocument();
         expect(typeof (title.textContent)).toBe('string');
-        expect(title.textContent).toEqual('Howdy Farmer Phillip!');
+        expect(title.textContent).toContain('Farmer Phillip!');
     });
 
     test("Redirects to the PlayPage when you click visit", async () => {

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
@@ -26,8 +26,8 @@ public class User {
     private String locale;
     private String hostedDomain;
     private boolean admin;
-    // @Builder.Default
-    // private boolean suspended = false;
+    @Builder.Default
+    private boolean suspended = false;
 
   @Builder.Default
   private Instant lastOnline = Instant.now();

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
@@ -26,8 +26,8 @@ public class User {
     private String locale;
     private String hostedDomain;
     private boolean admin;
-    @Builder.Default
-    private boolean suspended = false;
+    // @Builder.Default
+    // private boolean suspended = false;
 
   @Builder.Default
   private Instant lastOnline = Instant.now();


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I implemented further features into the UI. I removed the ID field from being visible to the users, and instead replaced it with a color background for each commons, that way two commons with the same name will still appear distinct. In addition, I changed the title on the home page to be rotating just like the title on the play page, this way every time you refresh the page you see a new greeting! I also made some stylistic changes in order to keep more consistency across the board such as expanding the box shadows to more aspects of the page, as well as changing the look of the join/visit buttons in order to make them more visually appealing and modern.

dokku deployment: https://happycows-nadavital-dev.dokku-07.cs.ucsb.edu/#

## Screenshots (Optional)
<img width="1512" alt="Screenshot 2024-05-26 at 11 20 32 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-7/assets/92344347/6ab6234a-ef89-4d66-8868-c58b8f1defcb">

## Tests
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
Continues work on #5 