### PR TITLE
zc - announcement page

### DIFF
--- a/frontend/src/main/pages/AdminListAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminListAnnouncementsPage.js
@@ -1,15 +1,41 @@
-import React from 'react';
+import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import AnnouncementTable from 'main/components/Announcement/AnnouncementTable';
+import { useBackend } from 'main/utils/useBackend';
+import { useCurrentUser } from "main/utils/currentUser";
+import { Button } from "react-bootstrap";
+import { useParams } from "react-router-dom";
 
-const AdminListAnnouncementsPage = () => {
-    // Stryker disable all : placeholder for future implementation
-  return (
-    <BasicLayout>
-      <div className="pt-2">
-        <h1>Admin List Announcements page not yet implemented</h1>
-      </div>
-    </BasicLayout>
-  )
+export default function AdminListAnnouncementsPage()
+{
+    const { commonsId } = useParams();
+    const { data: currentUser} = useCurrentUser();
+
+    // Stryker disable all
+    const { data: announcements, error: _error, status: _status } = useBackend(
+        [`/api/announcements/all?commonsId=${commonsId}`],
+        { method: "GET", url: `/api/announcements/all`, params: { commonsId } },
+        []
+    );
+    // Stryker restore all
+
+    const createButton = () => {
+        return (
+            <Button href={`/admin/announcements/${commonsId}/create`}
+            style={{ float: "right" }}
+            >
+                Create Announcement
+            </Button>
+        );
+    }
+
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                <h2>Announcements for Commons {commonsId}</h2>
+                {createButton()}
+                <AnnouncementTable announcements={announcements} currentUser={currentUser} />
+            </div>
+        </BasicLayout>
+  );
 };
-
-export default AdminListAnnouncementsPage;

--- a/frontend/src/main/pages/AdminListAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminListAnnouncementsPage.js
@@ -3,7 +3,6 @@ import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import AnnouncementTable from 'main/components/Announcement/AnnouncementTable';
 import { useBackend } from 'main/utils/useBackend';
 import { useCurrentUser } from "main/utils/currentUser";
-import { Button } from "react-bootstrap";
 import { useParams } from "react-router-dom";
 
 export default function AdminListAnnouncementsPage()

--- a/frontend/src/main/pages/AdminListAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminListAnnouncementsPage.js
@@ -19,21 +19,12 @@ export default function AdminListAnnouncementsPage()
     );
     // Stryker restore all
 
-    const createButton = () => {
-        return (
-            <Button href={`/admin/announcements/${commonsId}/create`}
-            style={{ float: "right" }}
-            >
-                Create Announcement
-            </Button>
-        );
-    }
+    
 
     return (
         <BasicLayout>
             <div className="pt-2">
                 <h2>Announcements for Commons {commonsId}</h2>
-                {createButton()}
                 <AnnouncementTable announcements={announcements} currentUser={currentUser} />
             </div>
         </BasicLayout>

--- a/frontend/src/tests/pages/AdminListAnnouncementsPage.test.js
+++ b/frontend/src/tests/pages/AdminListAnnouncementsPage.test.js
@@ -1,19 +1,31 @@
-import React from 'react';
-import { render, screen } from "@testing-library/react";
-import AdminListAnnouncementsPage from 'main/pages/AdminListAnnouncementsPage';
+import { render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
-
-import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
-import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { MemoryRouter, useParams } from "react-router-dom";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import AdminListAnnouncementsPage from "main/pages/AdminListAnnouncementsPage";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { announcementFixtures } from "fixtures/announcementFixtures";
 
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useParams: jest.fn(),
+}));
 
 describe("AdminListAnnouncementsPage tests", () => {
-
     const axiosMock = new AxiosMockAdapter(axios);
-
+    const testId = "AnnouncementTable";
 
     const setupAdminUser = () => {
         axiosMock.reset();
@@ -22,13 +34,15 @@ describe("AdminListAnnouncementsPage tests", () => {
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
     };
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
-
+    test("Renders Create Button for admin user", async () => {
         setupAdminUser();
+        const queryClient = new QueryClient();
+        const commonsId = 1;
 
-        // act
+        useParams.mockReturnValue({ commonsId });
+
+        axiosMock.onGet(`/api/announcements/all`, { params: { commonsId } }).reply(200, []);
+
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -37,8 +51,34 @@ describe("AdminListAnnouncementsPage tests", () => {
             </QueryClientProvider>
         );
 
-        // assert
-        expect(screen.getByText("Admin List Announcements page not yet implemented")).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByText(/Create Announcement/)).toBeInTheDocument();
+        });
+        const button = screen.getByText(/Create Announcement/);
+        expect(button).toHaveAttribute("style", "float: right;");
+        expect(button).toHaveAttribute("href", "/admin/announcements/1/create");
     });
 
+    test("Announcements listed for admin user", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        const commonsId = 1;
+
+        useParams.mockReturnValue({ commonsId });
+
+        axiosMock.onGet(`/api/announcements/all`, { params: { commonsId } }).reply(200, announcementFixtures.threeAnnouncements);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminListAnnouncementsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        await waitFor(() => {
+            expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+        });
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+    });
 });

--- a/frontend/src/tests/pages/AdminListAnnouncementsPage.test.js
+++ b/frontend/src/tests/pages/AdminListAnnouncementsPage.test.js
@@ -34,30 +34,7 @@ describe("AdminListAnnouncementsPage tests", () => {
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
     };
 
-    test("Renders Create Button for admin user", async () => {
-        setupAdminUser();
-        const queryClient = new QueryClient();
-        const commonsId = 1;
-
-        useParams.mockReturnValue({ commonsId });
-
-        axiosMock.onGet(`/api/announcements/all`, { params: { commonsId } }).reply(200, []);
-
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <AdminListAnnouncementsPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-
-        await waitFor(() => {
-            expect(screen.getByText(/Create Announcement/)).toBeInTheDocument();
-        });
-        const button = screen.getByText(/Create Announcement/);
-        expect(button).toHaveAttribute("style", "float: right;");
-        expect(button).toHaveAttribute("href", "/admin/announcements/1/create");
-    });
+    
 
     test("Announcements listed for admin user", async () => {
         setupAdminUser();

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
@@ -95,7 +95,7 @@ public class AnnouncementsController extends ApiController{
 
     @Operation(summary = "Get all announcements", description = "Get all announcements associated with a specific commons.")
     @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
-    @GetMapping("/getbycommonsid")
+    @GetMapping("/all")
     public ResponseEntity<Object> getAnnouncements(@Parameter(description = "The id of the common") @RequestParam Long commonsId) {
 
         // Make sure the user is part of the commons or is an admin
@@ -113,7 +113,7 @@ public class AnnouncementsController extends ApiController{
 
         int MAX_ANNOUNCEMENTS = 1000;
         Page<Announcement> announcements = announcementRepository.findByCommonsId(commonsId, PageRequest.of(0, MAX_ANNOUNCEMENTS, Sort.by("startDate").descending()));
-        return ResponseEntity.ok(announcements);
+        return ResponseEntity.ok(announcements.getContent());
     }
 
     @Operation(summary = "Get announcements by id", description = "Get announcement by its id.")

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
@@ -358,7 +358,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.empty());
 
         //act 
-        MvcResult response = mockMvc.perform(get("/api/announcements/a?commonsId={commonsId}", commonsId))
+        MvcResult response = mockMvc.perform(get("/api/announcements/all?commonsId={commonsId}", commonsId))
             .andExpect(status().isBadRequest()).andReturn();
 
         // assert

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
@@ -318,13 +318,13 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.of(userCommons));
 
         //act 
-        MvcResult response = mockMvc.perform(get("/api/announcements/getbycommonsid?commonsId={commonsId}", commonsId))
+        MvcResult response = mockMvc.perform(get("/api/announcements/all?commonsId={commonsId}", commonsId))
             .andExpect(status().isOk()).andReturn();
 
         // assert
         verify(announcementRepository, atLeastOnce()).findByCommonsId(commonsId, pageable);
         String responseString = response.getResponse().getContentAsString();
-        String expectedResponseString = mapper.writeValueAsString(announcementPage);
+        String expectedResponseString = mapper.writeValueAsString(announcementPage.getContent());
         assertEquals(expectedResponseString, responseString);
     }
 
@@ -358,7 +358,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.empty());
 
         //act 
-        MvcResult response = mockMvc.perform(get("/api/announcements/getbycommonsid?commonsId={commonsId}", commonsId))
+        MvcResult response = mockMvc.perform(get("/api/announcements/a?commonsId={commonsId}", commonsId))
             .andExpect(status().isBadRequest()).andReturn();
 
         // assert
@@ -390,13 +390,13 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         when(announcementRepository.findByCommonsId(commonsId, pageable)).thenReturn(announcementPage);
 
         //act 
-        MvcResult response = mockMvc.perform(get("/api/announcements/getbycommonsid?commonsId={commonsId}", commonsId))
+        MvcResult response = mockMvc.perform(get("/api/announcements/all?commonsId={commonsId}", commonsId))
             .andExpect(status().isOk()).andReturn();
 
         // assert
         verify(announcementRepository, atLeastOnce()).findByCommonsId(commonsId, pageable);
         String responseString = response.getResponse().getContentAsString();
-        String expectedResponseString = mapper.writeValueAsString(announcementPage);
+        String expectedResponseString = mapper.writeValueAsString(announcementPage.getContent());
         assertEquals(expectedResponseString, responseString);
     }
 


### PR DESCRIPTION
## Overview
Announcement index page implemented for admin user, and has a Create Announcement button.

## Screenshots
<img width="793" alt="Screenshot 2024-06-05 at 18 05 22" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-7/assets/17016528/2f81b936-0336-4578-95c1-d1dfc2f97975">

## Validation
https://happycows-qa.dokku-07.cs.ucsb.edu

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
related to issue #4 
