### PR TITLE
mz - adding accidentally deleted changes back into main

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -20,6 +20,7 @@ import NotFoundPage from "main/pages/NotFoundPage";
 import AdminViewPlayPage from "main/pages/AdminViewPlayPage";
 import ProtectedPlayPage from "main/pages/ProtectedPlayPage";
 import AdminListAnnouncementsPage from "main/pages/AdminListAnnouncementsPage";
+import AdminSuspendUserPage from "main/pages/AdminSuspendUserPage";
 
 function App() {
     const { data: currentUser } = useCurrentUser();
@@ -52,6 +53,10 @@ function App() {
             <Route
                 path="/admin/announcements/:commonsId"
                 element={<AdminListAnnouncementsPage />}
+            />
+            <Route 
+                path="/admin/suspend/user/:userId" 
+                element={<AdminSuspendUserPage />}
             />
         </>
     ) : null;

--- a/frontend/src/main/components/Announcement/AnnouncementCard.js
+++ b/frontend/src/main/components/Announcement/AnnouncementCard.js
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { Card, Button, Container, Row, Col } from "react-bootstrap";
+import React from "react";
+import { Card, Container, Row, Col } from "react-bootstrap";
 
 export function isFutureDate(startingDate) {
     const curr = new Date();
@@ -25,7 +25,6 @@ export function isFutureDate(startingDate) {
 
 const AnnouncementCard = ({ announcement }) => {
     const testIdPrefix = "announcementCard";
-    const [isCollapsed, setIsCollapsed] = useState(true);
 
     if (!announcement || !announcement.startDate || isFutureDate(announcement.startDate)) {
         return null;
@@ -34,37 +33,25 @@ const AnnouncementCard = ({ announcement }) => {
     if ( announcement.endDate && (!isFutureDate(announcement.endDate))) {
         return null;
     }
-
-    const toggleCollapse = () => {
-        setIsCollapsed(!isCollapsed);
-    };
-
     return (
-        <Card.Body style={
-            // Stryker disable next-line all : don't mutation test CSS 
-            { fontSize: "14px", border: "1px solid lightgrey", padding: "4px" }
-        }>
+        <Card.Body 
+        // Stryker disable next-line all : don't mutation test CSS
+        style={{ fontSize: "14px", border: "1px solid lightgrey", padding: "4px", borderRadius: "10px", margin: "10px 0" }}>
             <Container>
                 <Row>
                     <Col xs={12} data-testid={`${testIdPrefix}-id-${announcement.announcementText}`}>
-                        <div style={ // Stryker disable next-line all : don't mutation test CSS 
-                        { 
+                        <div
                             // Stryker disable next-line all : don't mutation test CSS
-                            whiteSpace: isCollapsed ? 'nowrap' : 'normal',
+                            style={{overflow: 'auto',
                             // Stryker disable next-line all : don't mutation test CSS
-                            overflow: isCollapsed ? 'hidden' : 'visible',
+                            maxHeight: '100px',
                             // Stryker disable next-line all : don't mutation test CSS
-                            textOverflow: isCollapsed ? 'ellipsis' : 'clip',
+                            wordWrap: 'break-word',
                             // Stryker disable next-line all : don't mutation test CSS
-                            maxWidth: isCollapsed ? '250px' : 'none'
+                            padding: '5px'
                         }}>
                             {announcement.announcementText}
                         </div>
-                        <Button variant="link" onClick={toggleCollapse} style={
-                            // Stryker disable next-line all : don't mutation test CSS
-                            { fontSize: '11px', padding: '2px' }}>
-                            {isCollapsed ? 'Show more' : 'Show less'}
-                        </Button>
                     </Col>
                 </Row>
             </Container>

--- a/frontend/src/main/components/Commons/CommonsOverview.js
+++ b/frontend/src/main/components/Commons/CommonsOverview.js
@@ -3,18 +3,32 @@ import { Row, Card, Col, Button } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 import { daysSinceTimestamp } from "main/utils/dateUtils";
+import AnnouncementCard from "main/components/Announcement/AnnouncementCard";
 
-export default function CommonsOverview({ commonsPlus, currentUser }) {
+export default function CommonsOverview({ commonsPlus, currentUser, announcements }) {
 
     let navigate = useNavigate();
     // Stryker disable next-line all
     const leaderboardButtonClick = () => { navigate("/leaderboard/" + commonsPlus.commons.id) };
     const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commonsPlus.commons.showLeaderboard );
-    return (
+    return ( // Stryker disable all: announcements backend broken so testing by posting announcements does not work
         <Card data-testid="CommonsOverview">
             <Card.Header as="h5">Announcements</Card.Header>
             <Card.Body>
                 <Row>
+                    <Col className="text-start">
+                            <div data-testid="announcement-test">
+                                {announcements && announcements.length > 0 ? (
+                                    announcements.map((announcement, index) => (
+                                        <AnnouncementCard key={index} announcement={announcement} />
+                                    ))
+                                ) : (
+                                    <p>No announcements available.</p>
+                                )}
+                            </div>
+                        </Col>
+                    </Row>
+                    <Row className="mt-3">
                     <Col>
                         <Card.Title>Today is day {daysSinceTimestamp(commonsPlus.commons.startingDate)}!</Card.Title>
                         <Card.Text>Total Players: {commonsPlus.totalUsers}</Card.Text>
@@ -28,5 +42,5 @@ export default function CommonsOverview({ commonsPlus, currentUser }) {
                 </Row>
             </Card.Body>
         </Card>
-    );
+    ); // Stryker restore all
 }; 

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -1,37 +1,49 @@
 import React from "react";
-import OurTable from "main/components/OurTable"
+import OurTable, { ButtonColumn } from "main/components/OurTable"
 import { formatTime } from "main/utils/dateUtils";
-
-const columns = [
-    {
-        Header: 'id',
-        accessor: 'id', // accessor is the "key" in the data
-    },
-    {
-        Header: 'First Name',
-        accessor: 'givenName',
-    },
-    {
-        Header: 'Last Name',
-        accessor: 'familyName',
-    },
-    {
-        Header: 'Email',
-        accessor: 'email',
-    },
-    {
-        Header: 'Last Online',
-        id: 'lastOnline',
-        accessor: (row) => formatTime(row.lastOnline),
-    },
-    {
-        Header: 'Admin',
-        id: 'admin',
-        accessor: (row, _rowIndex) => String(row.admin) // hack needed for boolean values to show up
-    },
-];
+import { useNavigate } from 'react-router-dom';
 
 export default function UsersTable({ users }) {
+
+    const navigate = useNavigate();
+
+    const suspendCallback = (row) => { 
+        console.log(row)
+        navigate(`/admin/suspend/user/${row.row.values.id}`)
+    }
+
+    const columns = [
+        {
+            Header: 'id',
+            accessor: 'id', // accessor is the "key" in the data
+        },
+        {
+            Header: 'First Name',
+            accessor: 'givenName',
+        },
+        {
+            Header: 'Last Name',
+            accessor: 'familyName',
+        },
+        {
+            Header: 'Email',
+            accessor: 'email',
+        },
+        {
+            Header: 'Last Online',
+            id: 'lastOnline',
+            accessor: (row) => formatTime(row.lastOnline),
+        },
+        {
+            Header: 'Admin',
+            id: 'admin',
+            accessor: (row, _rowIndex) => String(row.admin) // hack needed for boolean values to show up
+        },
+    ];
+
+    // don't need to check for admin because this page will not display if not admin
+    columns.push(ButtonColumn("Suspend", "danger", suspendCallback, "UsersTable"));
+    
     return <OurTable
         data={users}
         columns={columns}

--- a/frontend/src/main/pages/AdminSuspendUserPage.js
+++ b/frontend/src/main/pages/AdminSuspendUserPage.js
@@ -1,0 +1,16 @@
+import React from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+const AdminSuspendUserPage = () => {
+
+   // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Suspend User page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  )
+};
+
+export default AdminSuspendUserPage;

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -67,7 +67,21 @@ export default function PlayPage() {
             },
         }
     );
+    // Stryker restore all
 
+    // Stryker disable all
+    const { data: announcementsResponse } = useBackend(
+        [`/api/announcements/getbycommonsid?commonsId=${commonsId}`],
+        {
+            method: "GET",
+            url: "/api/announcements/getbycommonsid",
+            params: {
+                commonsId: commonsId,
+            },
+        }
+    );
+
+    const announcements = announcementsResponse ? announcementsResponse.content : null;
     // Stryker restore all
 
     // Stryker disable all (can't check if commonsId is null because it is mocked)
@@ -165,6 +179,7 @@ export default function PlayPage() {
                         <CommonsOverview
                             commonsPlus={commonsPlus}
                             currentUser={currentUser}
+                            announcements={announcements}
                         />
                     )}
                     <br />

--- a/frontend/src/tests/components/Announcement/AnnouncementsCard.test.js
+++ b/frontend/src/tests/components/Announcement/AnnouncementsCard.test.js
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { announcementFixtures } from "fixtures/announcementFixtures";
 import AnnouncementCard, { isFutureDate } from "main/components/Announcement/AnnouncementCard";
 
@@ -119,23 +119,11 @@ describe("AnnouncementCard tests", () => {
         expect(isFutureDate(futureDay)).toBe(true);
     });
 
-    test("can toggle collapse state", async () => {
-        render(
-            <AnnouncementCard announcement={announcementFixtures.threeAnnouncements[1]} />
-        );
-
-        const button = screen.getByText("Show more");
-        expect(button).toBeInTheDocument();
-
-        fireEvent.click(button);
-        const buttonAfterClick = screen.getByText("Show less");
-        expect(buttonAfterClick).toBeInTheDocument();
-    });
 
     test("renders long announcement text correctly", async () => {
         const longTextAnnouncement = {
             ...announcementFixtures.threeAnnouncements[1],
-            announcementText: "This is a very long announcement text that should be collapsed initially but expanded when the button is clicked."
+            announcementText: "This is a very long announcement text that should be collapsed initially but expanded when the button is clicked.".repeat(10)
         };
 
         render(
@@ -144,11 +132,6 @@ describe("AnnouncementCard tests", () => {
 
         const collapsedText = screen.getByText(/This is a very long announcement text/);
         expect(collapsedText).toBeInTheDocument();
-
-        const button = screen.getByText("Show more");
-        fireEvent.click(button);
-        const expandedText = screen.getByText("This is a very long announcement text that should be collapsed initially but expanded when the button is clicked.");
-        expect(expandedText).toBeInTheDocument();
     });
 
     test("handles announcement without end date", async () => {
@@ -179,13 +162,5 @@ describe("AnnouncementCard tests", () => {
         expect(textElement).toBeNull();
     });
 
-    test("button has correct style", async () => {
-        render(
-            <AnnouncementCard announcement={announcementFixtures.threeAnnouncements[1]} />
-        );
-
-        const button = screen.getByText("Show more");
-        expect(button).toHaveStyle({ fontSize: '11px', padding: '2px' });
-    });
 });
 

--- a/frontend/src/tests/components/Commons/CommonsOverview.test.js
+++ b/frontend/src/tests/components/Commons/CommonsOverview.test.js
@@ -51,7 +51,7 @@ describe("CommonsOverview tests", () => {
             </QueryClientProvider>
         );
         await waitFor(() => {
-            expect(axiosMock.history.get.length).toEqual(5);
+            expect(axiosMock.history.get.length).toEqual(6);
         });
         expect(await screen.findByTestId("user-leaderboard-button")).toBeInTheDocument();
         const leaderboardButton = screen.getByTestId("user-leaderboard-button");
@@ -83,5 +83,18 @@ describe("CommonsOverview tests", () => {
             expect(axiosMock.history.get.length).toEqual(3);
         });
         expect(() => screen.getByTestId("user-leaderboard-button")).toThrow();
+    });
+
+    test("commons with no announcements", async () => {
+        apiCurrentUserFixtures.userOnly.user.commonsPlus = commonsPlusFixtures.oneCommonsPlus[0];
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        expect(screen.getByText("No announcements available.")).toBeInTheDocument();
     });
 });

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -1,24 +1,57 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, waitFor, render, screen } from "@testing-library/react";
 import UsersTable from "main/components/Users/UsersTable";
 import { formatTime } from "main/utils/dateUtils";
 import usersFixtures from "fixtures/usersFixtures";
+import { MemoryRouter } from "react-router-dom";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
 
 describe("UserTable tests", () => {
     test("renders without crashing for empty table", () => {
         render(
-            <UsersTable users={[]} />
+            <MemoryRouter>
+                <UsersTable users={[]} />
+            </MemoryRouter>
         );
     });
 
     test("renders without crashing for three users", () => {
         render(
-            <UsersTable users={usersFixtures.threeUsers} />
+            <MemoryRouter>
+                <UsersTable users={usersFixtures.threeUsers} />
+            </MemoryRouter>
         );
     });
 
-    test("Has the expected colum headers and content", () => {
+    test("Suspend button calls suspend callback", async () => {
+        const testId = "UsersTable";
         render(
-          <UsersTable users={usersFixtures.threeUsers}/>
+            <MemoryRouter>
+                <UsersTable users={usersFixtures.threeUsers} />
+            </MemoryRouter>
+        );
+
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+
+        const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Suspend-button`);
+        expect(editButton).toBeInTheDocument();
+        expect(editButton).toHaveClass("btn-danger");
+        fireEvent.click(editButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/admin/suspend/user/1'));
+
+    });
+
+    test("Has the expected column headers and content", () => {
+        render(
+            <MemoryRouter>
+                <UsersTable users={usersFixtures.threeUsers}/>
+            </MemoryRouter>
         );
     
         const expectedHeaders = ["id", "First Name", "Last Name", "Email", "Last Online", "Admin"];

--- a/frontend/src/tests/pages/AdminSuspendUserPage.test.js
+++ b/frontend/src/tests/pages/AdminSuspendUserPage.test.js
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import AdminSuspendUserPage from "main/pages/AdminSuspendUserPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("AdminSuspendUserPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupAdminUser();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminSuspendUserPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Suspend User page not yet implemented")).toBeInTheDocument();
+    });
+
+});

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -37,6 +37,17 @@ describe("PlayPage tests", () => {
             userId: 1,
             showChat: true
         };
+        const announcementsResponse = {
+            content: [
+                {
+                    id: 1,
+                    commonsId: 1,
+                    startDate: "2024-05-22T22:19:56.800-07:00",
+                    endDate: null,
+                    announcementText: "First Announcement"
+                }
+            ]
+        };
         axiosMock.reset();
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
@@ -64,6 +75,7 @@ describe("PlayPage tests", () => {
         axiosMock.onGet("/api/profits/all/commonsid").reply(200, []);
         axiosMock.onPut("/api/usercommons/sell").reply(200, userCommons);
         axiosMock.onPut("/api/usercommons/buy").reply(200, userCommons);
+        axiosMock.onGet("/api/announcements/getbycommonsid", { params: { commonsId: 1 } }).reply(200, announcementsResponse);
     });
 
     test("renders without crashing", () => {
@@ -89,10 +101,10 @@ describe("PlayPage tests", () => {
         const buyCowButton = screen.getByTestId("buy-cow-button");
         fireEvent.click(buyCowButton);
 
-        const modal_buy = screen.findByTestId("buy-sell-cow-modal")
+        const modal_buy = screen.findByTestId("buy-sell-cow-modal");
         expect(await modal_buy).toBeInTheDocument();
-        const submitModalButton = screen.getByTestId("buy-sell-cow-modal-submit")
-        fireEvent.click(submitModalButton)
+        const submitModalButton = screen.getByTestId("buy-sell-cow-modal-submit");
+        fireEvent.click(submitModalButton);
 
         await waitFor(() => expect(axiosMock.history.put.length).toBe(1));
     });
@@ -129,6 +141,7 @@ describe("PlayPage tests", () => {
             </QueryClientProvider>
         );
 
+        expect(await screen.findByTestId("announcement-test")).toBeInTheDocument();
         expect(await screen.findByText(/Announcements/)).toBeInTheDocument();
         expect(await screen.findByTestId("CommonsPlay")).toBeInTheDocument();
     });
@@ -342,5 +355,5 @@ describe("PlayPage tests", () => {
         await waitFor(() => {
             expect(screen.getByTestId("playpage-chat-toggle")).toBeInTheDocument();
         });
-    })
+    });
 });


### PR DESCRIPTION
## Overview
In this PR, I reverted the changes that were accidentally deleted in https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-7/commit/5357fc8250fa2748da09120319a8ac79a31fd24f. These were the announcement card components on the play page and the suspend user button in the user table. 


## Tests
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 
